### PR TITLE
[FEAT] 챌린지 수락/거절 기능 구현 및 주최자 관련 부분 추가

### DIFF
--- a/src/main/java/com/dnd/ground/domain/challenge/ChallengeStatus.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/ChallengeStatus.java
@@ -1,16 +1,19 @@
 package com.dnd.ground.domain.challenge;
 
 /**
- * @description 챌린지 상태
+ * @description 챌린지 상태(Challenge, UserChallenge 둘 다 사용)
  *              Wait     - 수락 대기
  *              Progress - 진행
  *              Done     - 종료
+ *              Reject   - 거절
+ *              Master   - 주최자
  * @author  박찬호
  * @since   2022-07-26
- * @updated 1. Waiting → Wait 변경
- *          - 2022-08-01 박찬호
+ * @updated 1. Master - 주최자 추가
+ *          2. Reject - 거절 추가
+ *          - 2022-08-08 박찬호
  */
 
 public enum ChallengeStatus {
-    Wait, Progress, Done
+    Wait, Progress, Done, Reject, Master
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/UserChallenge.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/UserChallenge.java
@@ -12,7 +12,8 @@ import javax.persistence.*;
  * @description User - Challenge 간 조인 테이블
  * @author  박찬호
  * @since   2022-07-27
- * @updated 2022-08-03 / 챌린지 수락 여부(status) 필드 추가
+ * @updated 1. 챌린지 생성 시, 주최자는 Master 상태로 초기화
+ *          - 2022-08-08 박찬호
  */
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,4 +45,8 @@ public class UserChallenge {
         this.status = ChallengeStatus.Wait;
     }
 
+    //챌린지 상태 변경
+    public void changeStatus(ChallengeStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.dnd.ground.domain.challenge.controller;
 
 import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -8,10 +9,12 @@ import org.springframework.web.bind.annotation.RequestBody;
  * @description 챌린지와 관련된 컨트롤러의 역할을 분리한 인터페이스
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1. 챌린지 생성 기능 구현
- *          - 2022.08.03 박찬호
+ * @updated 1. 챌린지 수락/거절 기능 구현
+ *          - 2022.08.08 박찬호
  */
 
 public interface ChallengeController {
     ResponseEntity<?> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto);
+    ResponseEntity<?> acceptChallenge(@RequestBody ChallengeRequestDto.Info requestDto);
+    ResponseEntity<?> rejectChallenge(@RequestBody ChallengeRequestDto.Info requestDto);
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
@@ -1,25 +1,23 @@
 package com.dnd.ground.domain.challenge.controller;
 
-import com.dnd.ground.domain.challenge.Challenge;
+import com.dnd.ground.domain.challenge.ChallengeStatus;
 import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
 import com.dnd.ground.domain.challenge.service.ChallengeService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 /**
  * @description 챌린지와 관련된 컨트롤러 구현체
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1. 챌린지 생성 기능 구현
- *          - 2022.08.03 박찬호
+ * @updated 1. 챌린지 수락/거절 기능 구현
+ *          - 2022.08.08 박찬호
  */
 
 @Api(tags = "챌린지")
@@ -30,11 +28,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChallengeControllerImpl implements ChallengeController {
 
     private final ChallengeService challengeService;
-    
+
     @PostMapping("/")
     @Operation(summary = "챌린지 생성", description = "챌린지 생성")
     public ResponseEntity<?> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto) {
         return challengeService.createChallenge(challengeCreateRequestDto);
     }
+
+    @PostMapping("/accept")
+    @Operation(summary = "챌린지 수락", description = "유저의 챌린지 수락")
+    public ResponseEntity<?> acceptChallenge(@RequestBody ChallengeRequestDto.Info requestDto) {
+        return challengeService.changeChallengeStatus(requestDto, ChallengeStatus.Progress);
+    }
+
+    @PostMapping("/reject")
+    @Operation(summary = "챌린지 거절", description = "유저의 챌린지 거절")
+    public ResponseEntity<?> rejectChallenge(@RequestBody ChallengeRequestDto.Info requestDto) {
+        return challengeService.changeChallengeStatus(requestDto, ChallengeStatus.Reject);
+    }
+
 
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateRequestDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateRequestDto.java
@@ -13,12 +13,12 @@ import java.time.LocalDate;
 import java.util.Set;
 
 /**
- * @description 챌린지와 관련한 Request DTO
+ * @description 챌린지 생성과 관련한 Request DTO
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. UUID 추가
- *          2. started 컬럼 데이터 타입 변경 및 직렬화, 역직렬화 어노테이션 추가
- *          - 2022.08.04 박찬호
+ * @updated 1. nickname 컬럼 추가
+ *          2. nicknames 컬럼명 변경 (nicknames -> friends)
+ *          - 2022.08.08 박찬호
  */
 
 @Data
@@ -28,6 +28,10 @@ public class ChallengeCreateRequestDto {
     @NotNull(message = "UUID가 필요합니다.")
     @ApiModelProperty(value="UUID", example="32개의 문자", required = true)
     private String uuid;
+
+    @NotNull(message = "주최자의 닉네임이 필요합니다.")
+    @ApiModelProperty(value="닉네임", example="NickA", required = true)
+    private String nickname;
     
     @NotNull(message = "챌린지 이름이 필요합니다.")
     @ApiModelProperty(value="챌린지 이름", example="챌린지1", required = true)
@@ -46,7 +50,7 @@ public class ChallengeCreateRequestDto {
     private LocalDate started;
 
     @NotNull(message = "함께하는 친구가 1명 이상이어야 합니다.")
-    @ApiModelProperty(value="함께하는 닉네임 리스트", example="[nick1, nick2 ...]", required = true)
-    private Set<String> nicknames;
+    @ApiModelProperty(value="함께하는 친구 닉네임 리스트", example="[nick1, nick2 ...]", required = true)
+    private Set<String> friends;
 
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeRequestDto.java
@@ -1,0 +1,31 @@
+package com.dnd.ground.domain.challenge.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * @description 챌린지와 관련한 Request DTO
+ * @author  박찬호
+ * @since   2022-08-08
+ * @updated 1. 유저-챌린지 정보를 얻기 위한 이너 클래스(Info) 생성
+ *          - 2022.08.08 박찬호
+ */
+
+
+@Data
+public class ChallengeRequestDto {
+
+    //유저-챌린지 정보를 위한 이너 클래스
+    @Data
+    static public class Info {
+        @NotNull(message = "UUID가 필요합니다.")
+        @ApiModelProperty(value="UUID", example="32개의 문자", required = true)
+        private String uuid;
+
+        @NotNull(message = "닉네임이 필요합니다.")
+        @ApiModelProperty(value="회원 닉네임", example="Nickname", required = true)
+        private String nickname;
+    }
+}

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  * @description 회원-챌린지 간 조인엔티티와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 챌린지에 참여한 회원 정보 조회
+ * @updated 1. 유저-챌린지 정보를 통한 UserChallenge 조회
  *          - 2022.08.08 박찬호
  */
 
@@ -38,5 +38,8 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     //챌린지에 포함된 회원 조회
     @Query("select uc.user from UserChallenge uc where uc.challenge=:challenge")
     List<User> findChallengeUsers(@Param("challenge") Challenge challenge);
+
+    //유저와 챌린지를 통해 UserChallenge 조회
+    Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
 
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
@@ -1,17 +1,20 @@
 package com.dnd.ground.domain.challenge.service;
 
+import com.dnd.ground.domain.challenge.ChallengeStatus;
 import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
 import org.springframework.http.ResponseEntity;
 
 /**
  * @description 챌린지와 관련된 서비스의 역할을 분리한 인터페이스
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 챌린지 생성 기능 구현
- *          - 2022.08.03 박찬호
+ * @updated 1. 챌린지 수락/거절 기능 구현
+ *          - 2022.08.08 박찬호
  */
 
 public interface ChallengeService {
 
     ResponseEntity<?> createChallenge(ChallengeCreateRequestDto challengeCreateRequestDto);
+    ResponseEntity<?> changeChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status);
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeServiceImpl.java
@@ -1,8 +1,10 @@
 package com.dnd.ground.domain.challenge.service;
 
 import com.dnd.ground.domain.challenge.Challenge;
+import com.dnd.ground.domain.challenge.ChallengeStatus;
 import com.dnd.ground.domain.challenge.UserChallenge;
 import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
+import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
 import com.dnd.ground.domain.challenge.repository.ChallengeRepository;
 import com.dnd.ground.domain.challenge.repository.UserChallengeRepository;
 import com.dnd.ground.domain.user.User;
@@ -18,8 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
  * @description 챌린지와 관련된 서비스의 역할을 분리한 구현체
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 주석 추가
- *          - 2022.08.05 박찬호
+ * @updated 1. 주최자 master 상태 변경
+ *          2. 챌린지 수락/거절 기능 구현
+ *          - 2022.08.08 박찬호
  */
 
 @RequiredArgsConstructor
@@ -34,6 +37,8 @@ public class ChallengeServiceImpl implements ChallengeService {
     @Transactional
     public ResponseEntity<?> createChallenge(ChallengeCreateRequestDto requestDto) {
 
+        User master = userRepository.findByNickName(requestDto.getNickname()).orElseThrow(); //예외 처리 예정
+
         Challenge challenge = Challenge.create()
                 .uuid(UuidUtil.createUUID())
                 .name(requestDto.getName())
@@ -44,12 +49,31 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         challengeRepository.save(challenge);
 
-        for (String nickname : requestDto.getNicknames()) {
+        for (String nickname : requestDto.getFriends()) {
             User user = userRepository.findByNickName(nickname).orElseThrow(); //예외 처리 예정
             userChallengeRepository.save(new UserChallenge(challenge, user));
         }
 
+        UserChallenge masterChallenge = userChallengeRepository.save(new UserChallenge(challenge, master));
+        masterChallenge.changeStatus(ChallengeStatus.Master);
+        
         return new ResponseEntity(HttpStatus.CREATED);
+    }
+
+    /*챌린지 상태 변경*/
+    @Transactional
+    public ResponseEntity<?> changeChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status) {
+        //정보 조회
+        Challenge challenge = challengeRepository.findByUuid(requestDto.getUuid());
+        User user = userRepository.findByNickName(requestDto.getNickname()).orElseThrow(); // 예외 처리 예정
+        //상태 변경
+        UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge).orElseThrow();
+        if (userChallenge.getStatus() == ChallengeStatus.Master) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        userChallenge.changeStatus(status);
+
+        return new ResponseEntity(HttpStatus.OK);
     }
 
 }


### PR DESCRIPTION
1. 챌린지 수락/거절 기능 구현
2. 챌린지 상태(ChallengeStatus) 추가(Master, Reject)
3. 챌린지 생성 시, 주최자는 Master 상태로 변경