### PR TITLE
FEAT: 일주일 챌린지 상태 관리 및 종류 추가

### DIFF
--- a/src/main/java/com/dnd/ground/GroundApplication.java
+++ b/src/main/java/com/dnd/ground/GroundApplication.java
@@ -2,7 +2,9 @@ package com.dnd.ground;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class GroundApplication {
 

--- a/src/main/java/com/dnd/ground/domain/challenge/Challenge.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/Challenge.java
@@ -6,15 +6,14 @@ import javax.persistence.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * @description 챌린지 엔티티
  * @author  박찬호
  * @since   2022-07-26
- * @updated 1.stared 컬럼 데이터 타입 변경 (LocalDateTime → LocalDate)
- *          2.UUID 컬럼 생성
- *          - 2022-08-04 박찬호
+ * @updated 1.type 필드 추가(챌린지 종류)
+ *          2.챌린지 상태 업데이트 메소드 추가(updateStatus())
+ *          - 2022-08-09 박찬호
  */
 
 @Getter
@@ -50,15 +49,25 @@ public class Challenge {
     @Builder.Default
     private ChallengeStatus status = ChallengeStatus.Wait;
 
-    @OneToMany(mappedBy = "user")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "challenge_type", nullable = false)
+    private ChallengeType type;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserChallenge> users = new ArrayList<>();
 
     @Builder(builderMethodName = "create")
-    public Challenge(String name, String uuid, LocalDate started, String message, String color) {
+    public Challenge(String name, String uuid, LocalDate started, String message, String color, ChallengeType type) {
         this.uuid = uuid;
         this.name = name;
         this.started = started;
         this.message = message;
         this.color = color;
+        this.type = type;
+    }
+
+    //챌린지 상태 업데이트
+    public void updateStatus(ChallengeStatus status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/ChallengeType.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/ChallengeType.java
@@ -1,0 +1,15 @@
+package com.dnd.ground.domain.challenge;
+
+/**
+ * @description 일주일 챌린지 종류
+ *              Accumulate  - 칸 많이 누적하기
+ *              Widen       - 영역 넓히기
+ * @author  박찬호
+ * @since   2022-08-09
+ * @updated 1. 일주일 챌린지 종류를 위한 ENUM 생성
+ *          - 2022-08-09 박찬호
+ */
+
+public enum ChallengeType {
+    Accumulate, Widen
+}

--- a/src/main/java/com/dnd/ground/domain/challenge/UserChallenge.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/UserChallenge.java
@@ -12,8 +12,8 @@ import javax.persistence.*;
  * @description User - Challenge 간 조인 테이블
  * @author  박찬호
  * @since   2022-07-27
- * @updated 1. 챌린지 생성 시, 주최자는 Master 상태로 초기화
- *          - 2022-08-08 박찬호
+ * @updated 1. 챌린지, 회원에 cascade 옵션 추가
+ *          - 2022-08-09 박찬호
  */
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateRequestDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateRequestDto.java
@@ -1,5 +1,6 @@
 package com.dnd.ground.domain.challenge.dto;
 
+import com.dnd.ground.domain.challenge.ChallengeType;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
@@ -16,9 +17,8 @@ import java.util.Set;
  * @description 챌린지 생성과 관련한 Request DTO
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. nickname 컬럼 추가
- *          2. nicknames 컬럼명 변경 (nicknames -> friends)
- *          - 2022.08.08 박찬호
+ * @updated 1. 챌린지 종류 필드 생성
+ *          - 2022.08.09 박찬호
  */
 
 @Data
@@ -48,6 +48,10 @@ public class ChallengeCreateRequestDto {
     @JsonSerialize(using= LocalDateSerializer.class)
     @ApiModelProperty(value = "챌린지 시작 시간", example = "2022-08-04")
     private LocalDate started;
+
+    @NotNull(message = "1개의 챌린지 종류가 필요합니다.")
+    @ApiModelProperty(value="챌린지 종류", example="Widen | Accumulate", required = true)
+    private ChallengeType type;
 
     @NotNull(message = "함께하는 친구가 1명 이상이어야 합니다.")
     @ApiModelProperty(value="함께하는 친구 닉네임 리스트", example="[nick1, nick2 ...]", required = true)

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
@@ -1,19 +1,21 @@
 package com.dnd.ground.domain.challenge.repository;
 
 import com.dnd.ground.domain.challenge.Challenge;
+import com.dnd.ground.domain.challenge.ChallengeStatus;
 import com.dnd.ground.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
  * @description 챌린지와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 진행 중인 챌린지 정보 조회 추가
- *          - 2022.08.08 박찬호
+ * @updated 1. 일주일 챌린지 시작 상태 변경 기능 추가
+ *          - 2022.08.09 박찬호
  */
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
@@ -39,4 +41,9 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     @Query("select c from Challenge c where c IN (select uc.challenge from UserChallenge uc where uc.user=:user) and " +
             "c.status='Progress' and c = (select uc.challenge from UserChallenge uc where uc.challenge=c and uc.user =:friend) order by c.id ASC")
     List<Challenge> findChallengesWithFriend(@Param("user")User user, @Param("friend") User friend);
+
+    //진행 중인 챌린지를 제외하고, 모든 챌린지 조회 -> Progress가 아니면서 시작 날짜가 오늘인 챌린지 조회
+    @Query("select c from Challenge c where c.status<>'Progress' and c.started=:today")
+    List<Challenge> findChallengesNotStarted(LocalDate today);
+
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
@@ -10,11 +10,14 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.List;
 
+import static com.dnd.ground.domain.challenge.ChallengeStatus.*;
+
 /**
  * @description 챌린지와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-03
  * @updated 1. 일주일 챌린지 시작 상태 변경 기능 추가
+ *          2. 일주일 챌린지 종료 기능 추가
  *          - 2022.08.09 박찬호
  */
 
@@ -45,5 +48,8 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     //진행 중인 챌린지를 제외하고, 모든 챌린지 조회 -> Progress가 아니면서 시작 날짜가 오늘인 챌린지 조회
     @Query("select c from Challenge c where c.status<>'Progress' and c.started=:today")
     List<Challenge> findChallengesNotStarted(LocalDate today);
+
+    //진행 중인 전체 챌린지 조회
+    List<Challenge> findChallengesByStatusEquals(ChallengeStatus Progress);
 
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
@@ -4,6 +4,7 @@ import com.dnd.ground.domain.challenge.Challenge;
 import com.dnd.ground.domain.challenge.UserChallenge;
 import com.dnd.ground.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,8 +15,8 @@ import java.util.Optional;
  * @description 회원-챌린지 간 조인엔티티와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 유저-챌린지 정보를 통한 UserChallenge 조회
- *          - 2022.08.08 박찬호
+ * @updated 1. 일주일 챌린지 시작 상태 변경 기능 추가
+ *          - 2022.08.09 박찬호
  */
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
@@ -42,4 +43,10 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     //유저와 챌린지를 통해 UserChallenge 조회
     Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
 
+    @Query("select uc from UserChallenge uc where uc.challenge=:challenge")
+    List<UserChallenge> findUCByChallenge(@Param("challenge") Challenge challenge);
+
+    @Modifying(clearAutomatically = true)
+    @Query("delete from UserChallenge uc where uc.challenge=:challenge and (uc.status='Wait' or uc.status='Reject')")
+    int deleteUCByChallenge(@Param("challenge") Challenge challenge);
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
@@ -9,12 +9,14 @@ import org.springframework.http.ResponseEntity;
  * @description 챌린지와 관련된 서비스의 역할을 분리한 인터페이스
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 챌린지 수락/거절 기능 구현
- *          - 2022.08.08 박찬호
+ * @updated 1. 일주일 챌린지 시작 상태 변경 기능 추가
+ *          - 2022.08.09 박찬호
  */
 
 public interface ChallengeService {
 
     ResponseEntity<?> createChallenge(ChallengeCreateRequestDto challengeCreateRequestDto);
-    ResponseEntity<?> changeChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status);
+    ResponseEntity<?> changeUserChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status);
+    void startPeriodChallenge();
+
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
  * @author  박찬호
  * @since   2022-08-03
  * @updated 1. 일주일 챌린지 시작 상태 변경 기능 추가
+ *          2. 일중리 챌린지 종료 기능 추가
  *          - 2022.08.09 박찬호
  */
 
@@ -18,5 +19,5 @@ public interface ChallengeService {
     ResponseEntity<?> createChallenge(ChallengeCreateRequestDto challengeCreateRequestDto);
     ResponseEntity<?> changeUserChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status);
     void startPeriodChallenge();
-
+    void endPeriodChallenge();
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeServiceImpl.java
@@ -11,20 +11,27 @@ import com.dnd.ground.domain.user.User;
 import com.dnd.ground.domain.user.repository.UserRepository;
 import com.dnd.ground.global.util.UuidUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 /**
  * @description 챌린지와 관련된 서비스의 역할을 분리한 구현체
  * @author  박찬호
  * @since   2022-08-03
- * @updated 1. 주최자 master 상태 변경
- *          2. 챌린지 수락/거절 기능 구현
- *          - 2022.08.08 박찬호
+ * @updated 1. 일주일 챌린지 종류 추가(type)
+ *          2. 일주일 챌린지 시작 상태 변경 기능 추가(Cron)
+ *          - 2022.08.09 박찬호
  */
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChallengeServiceImpl implements ChallengeService {
@@ -45,6 +52,7 @@ public class ChallengeServiceImpl implements ChallengeService {
                 .started(requestDto.getStarted())
                 .message(requestDto.getMessage()) //메시지 처리 방식 결과에 따라 수정 요망
                 .color(requestDto.getColor())
+                .type(requestDto.getType())
                 .build();
 
         challengeRepository.save(challenge);
@@ -56,13 +64,13 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         UserChallenge masterChallenge = userChallengeRepository.save(new UserChallenge(challenge, master));
         masterChallenge.changeStatus(ChallengeStatus.Master);
-        
+
         return new ResponseEntity(HttpStatus.CREATED);
     }
 
-    /*챌린지 상태 변경*/
+    /*유저-챌린지 상태 변경*/
     @Transactional
-    public ResponseEntity<?> changeChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status) {
+    public ResponseEntity<?> changeUserChallengeStatus(ChallengeRequestDto.Info requestDto, ChallengeStatus status) {
         //정보 조회
         Challenge challenge = challengeRepository.findByUuid(requestDto.getUuid());
         User user = userRepository.findByNickName(requestDto.getNickname()).orElseThrow(); // 예외 처리 예정
@@ -76,4 +84,35 @@ public class ChallengeServiceImpl implements ChallengeService {
         return new ResponseEntity(HttpStatus.OK);
     }
 
+    /*챌린지 상태 변경(매일 00:00 실행)*/
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * *")
+    public void startPeriodChallenge() {
+        //챌린지 시작일이 오늘인 챌린지 리스트
+        List<Challenge> challenges = challengeRepository.findChallengesNotStarted(LocalDate.now());
+        int countDelete = 0; //삭제된 챌린지 수
+        int countUser = 0; //삭제된 유저 수
+        int countProgress = 0; // 진행 상태로 바뀐 챌린지 수
+
+        for (Challenge challenge : challenges) {
+            //Wait, Reject 상태의 유저 삭제
+            countUser += userChallengeRepository.deleteUCByChallenge(challenge);
+
+            List<UserChallenge> userChallenge = userChallengeRepository.findUCByChallenge(challenge);
+
+            //주최자만 남은 경우 챌린지와 주최자 삭제
+            if (userChallenge.size() == 1) {
+                userChallengeRepository.delete(userChallenge.get(0));
+                challengeRepository.delete(challenge);
+                countDelete++;
+            }
+            //챌린지 진행 상태로 변경
+            else {
+                challenge.updateStatus(ChallengeStatus.Progress);
+            }
+        }
+
+        log.info("**챌린지 시작 메소드 실행** 현재 시간:{} | 삭제된 챌린지 개수:{} | 삭제된 유저 수:{} | 진행 상태로 바뀐 챌린지 개수:{}",
+                LocalDateTime.now(), countDelete, countUser, countProgress);
+    }
 }

--- a/src/main/java/com/dnd/ground/domain/user/User.java
+++ b/src/main/java/com/dnd/ground/domain/user/User.java
@@ -17,6 +17,7 @@ import java.util.List;
  * @since   2022.07.28
  * @updated 1. 회원의 마지막 위치에 관한 필드 추가(latitude, longitude)
  *          2. 마지막 위치 최신화를 위한 메소드 추가(updatePosition)
+ *          3. 챌린지 관련 cascade 옵션 추가
  *          - 2022.08.09 박찬호
  */
 
@@ -60,7 +61,7 @@ public class User {
     @OneToMany(mappedBy = "friend")
     private List<Friend> friends = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserChallenge> challenges = new ArrayList<>();
 
     @OneToMany(mappedBy = "user")

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,16 +1,16 @@
 -- 회원 생성
-insert into user values(1, "M", 178.2, "A-mail@gmail.com", "NickA", "UserA", "70.5");
-insert into user values(2, "F", 164.1, "B-mail@naver.com", "NickB", "UserB", "58.2");
-insert into user values(3, "M", 186.6, "C-mail@daum.com", "NickC", "UserC", "74.8");
+insert into user values(1, "M", 178.2, null, null, "A-mail@gmail.com", "NickA", "UserA", "70.5");
+insert into user values(2, "F", 164.1, null, null, "B-mail@naver.com", "NickB", "UserB", "58.2");
+insert into user values(3, "M", 186.6, null, null, "C-mail@daum.com", "NickC", "UserC", "74.8");
 
-insert into user values(4, "F", 158.0, "D-mail@gmail.com", "NickD", "UserD", "46.5");
-insert into user values(5, "M", 172.9, "E-mail@dnd.com", "NickE", "UserE", "73.1");
+insert into user values(4, "F", 158.0, null, null, "D-mail@gmail.com", "NickD", "UserD", "46.5");
+insert into user values(5, "M", 172.9, null, null, "E-mail@dnd.com", "NickE", "UserE", "73.1");
 
-insert into user values(6, "M", 174.3, "F-mail@gmail.com", "NickF", "UserF", "70.2");
-insert into user values(7, "F", 170.3, "G-mail@naver.com", "NickG", "UserG", "60.6");
+insert into user values(6, "M", 174.3, null, null, "F-mail@gmail.com", "NickF", "UserF", "70.2");
+insert into user values(7, "F", 170.3, null, null, "G-mail@naver.com", "NickG", "UserG", "60.6");
 
-insert into user values(8, "M", 182.1, "H-mail@dnd.com", "NickH", "UserH", "74.3");
-insert into user values(9, "M", 177.8, "I-mail@daum.com", "NickI", "UserI", "72.7");
+insert into user values(8, "M", 182.1, null, null, "H-mail@dnd.com", "NickH", "UserH", "74.3");
+insert into user values(9, "M", 177.8, null, null, "I-mail@daum.com", "NickI", "UserI", "72.7");
 
 -- 친구 관계 생성
 insert into friend values(1, "Accept", 1, 2);
@@ -21,3 +21,5 @@ insert into friend values(3, "Accept", 4, 5);
 insert into friend values(4, "Wait", 6, 7);
 
 insert into friend values(5, "Reject", 8, 9);
+
+insert into friend values(6, "Accept", 2, 3);


### PR DESCRIPTION
1. 매일 자정 **일주일 챌린지 시작** 상태 변경 및 대기·거절 상태 회원 삭제(Cron)
2. 매 주 일요일 오후 11시 59분 50초 **일주일 챌린지 종료**
3. 이에 따른 User, Challenge와 UserChallenge에 cascade 옵션 추가
4. 일주일 챌린지 종류 선택을 위한 type 필드 추가