### PR TITLE
[FEAT | MODIFY] 유저와 관련된 request dto 생성 및 역대 누적 랭킹 조회 기능

### DIFF
--- a/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordController.java
+++ b/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordController.java
@@ -1,6 +1,8 @@
 package com.dnd.ground.domain.exerciseRecord.controller;
 
 import com.dnd.ground.domain.exerciseRecord.dto.EndRequestDto;
+import com.dnd.ground.domain.user.dto.RankResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,4 +17,5 @@ import org.springframework.web.bind.annotation.*;
 public interface RecordController {
     ResponseEntity<?> start(@RequestParam("nickname") String nickname);
     ResponseEntity<?> end(@RequestBody EndRequestDto endRequestDto);
+    ResponseEntity<RankResponseDto.Step> matrixRank(@RequestBody UserRequestDto.LookUp requestDto);
 }

--- a/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordControllerImpl.java
@@ -4,6 +4,7 @@ import com.dnd.ground.domain.exerciseRecord.dto.EndRequestDto;
 import com.dnd.ground.domain.exerciseRecord.dto.StartResponseDto;
 import com.dnd.ground.domain.exerciseRecord.service.ExerciseRecordService;
 import com.dnd.ground.domain.user.dto.RankResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -44,15 +45,8 @@ public class RecordControllerImpl implements RecordController{
     }
 
     @GetMapping("/rank/step")
-    @Operation(summary = "걸음수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 걸음수가 높은 순서대로 유저와 친구들을 조회(추후 nickname, start, end를 가진 requestDto 생성 예정)유저들을 조회")
-    public ResponseEntity<RankResponseDto.Step> matrixRank(@RequestParam("nickname") String nickName){
-
-        /* 추후 nickname, start, end를 가진 requestDto 생성 예정 */
-        LocalDateTime result = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDateTime start = LocalDateTime.of(result.getYear(), result.getMonth(), result.getDayOfMonth(), 0, 0, 0);
-        LocalDateTime end = LocalDateTime.now();
-        /* 임시로 이번주 기록 */
-
-        return ResponseEntity.ok(exerciseRecordService.stepRanking(nickName, start, end));
+    @Operation(summary = "걸음수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 걸음수가 높은 순서대로 유저와 친구들을 조회")
+    public ResponseEntity<RankResponseDto.Step> matrixRank(@RequestBody UserRequestDto.LookUp requestDto){
+        return ResponseEntity.ok(exerciseRecordService.stepRanking(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }
 }

--- a/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/exerciseRecord/controller/RecordControllerImpl.java
@@ -45,7 +45,10 @@ public class RecordControllerImpl implements RecordController{
     }
 
     @GetMapping("/rank/step")
-    @Operation(summary = "걸음수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 걸음수가 높은 순서대로 유저와 친구들을 조회")
+    @Operation(summary = "걸음수 랭킹",
+            description = "해당 유저를 기준으로 start-end(기간) 사이 걸음수가 높은 순서대로 유저와 친구들을 조회\n" +
+                    "start: 해당 주 월요일 00시 00분 00초\n" +
+                    "end: 해당 주 일요일 23시 59분 59초")
     public ResponseEntity<RankResponseDto.Step> matrixRank(@RequestBody UserRequestDto.LookUp requestDto){
         return ResponseEntity.ok(exerciseRecordService.stepRanking(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }

--- a/src/main/java/com/dnd/ground/domain/exerciseRecord/dto/RecordResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/exerciseRecord/dto/RecordResponseDto.java
@@ -14,9 +14,8 @@ import java.util.List;
  *              2. 활동 기록 response Dto
  * @author  박세헌, 박찬호
  * @since   2022-08-16
- * @updated 1. api명세 수정
- *          2. started, ended, exerciseTime 필드 string으로 formatting
- *          - 2020-08-17 박세헌
+ * @updated 운동 시작 시간, 끝 시간 날짜 분리
+ *          - 2022-08-18 박세헌
  */
 
 @Data
@@ -27,10 +26,13 @@ public class RecordResponseDto {
         @ApiModelProperty(value = "운동기록 id", example = "1")
         private Long recordId;
 
-        @ApiModelProperty(value="운동 기록 시작 시간", example="12월 25일 토요일 18:04")
+        @ApiModelProperty(value = "해당 기록의 날짜", example = "07월 25일 토요일")
+        private String date;
+
+        @ApiModelProperty(value="운동 기록 시작 시간", example="18:04")
         private String started;
 
-        @ApiModelProperty(value="운동 기록 끝 시간", example="12월 25일 토요일 18:07")
+        @ApiModelProperty(value="운동 기록 끝 시간", example="18:07")
         private String ended;
 
         @ApiModelProperty(value="해당 기록의 채운 칸의 수", example="9")

--- a/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixController.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixController.java
@@ -1,10 +1,20 @@
 package com.dnd.ground.domain.matrix.controller;
 
 import com.dnd.ground.domain.user.dto.RankResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+/**
+ * @description 메인홈 구성 컨트롤러 인터페이스
+ * @author  박세헌, 박찬호
+ * @since   2022-08-02
+ * @updated  nickname, start, end 가진 requestDto 생성
+ *          - 2022-08-18 박세헌
+ */
+
 public interface MatrixController {
-    ResponseEntity<RankResponseDto.Matrix> matrixRank(@RequestParam("nickname") String nickName);
-    ResponseEntity<RankResponseDto.Area> areaRank(@RequestParam("nickname") String nickName);
+    ResponseEntity<RankResponseDto.Matrix> matrixRank(@RequestParam String nickname);
+    ResponseEntity<RankResponseDto.Area> areaRank(@RequestBody UserRequestDto.LookUp requestDto);
 }

--- a/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixControllerImpl.java
@@ -1,10 +1,8 @@
 package com.dnd.ground.domain.matrix.controller;
 
 import com.dnd.ground.domain.matrix.matrixService.MatrixService;
-import com.dnd.ground.domain.user.User;
 import com.dnd.ground.domain.user.dto.RankResponseDto;
 import com.dnd.ground.domain.user.dto.UserRequestDto;
-import com.dnd.ground.domain.user.repository.UserRepository;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjusters;
 
 /**
  * @description 메인홈 구성 컨트롤러 인터페이스
@@ -33,21 +28,18 @@ import java.time.temporal.TemporalAdjusters;
 public class MatrixControllerImpl implements MatrixController {
 
     private final MatrixService matrixService;
-    private final UserRepository userRepository;
 
     @GetMapping("/rank/accumulate")
     @Operation(summary = "역대 누적 칸의 수 랭킹", description = "해당 유저를 기준으로 가입날짜 ~ 오늘 사이 누적 칸의 수가 높은 순서대로 유저와 친구들을 조회")
     public ResponseEntity<RankResponseDto.Matrix> matrixRank(@RequestParam("nickname") String nickname){
-
-        User user = userRepository.findByNickname(nickname).orElseThrow();
-        LocalDateTime start = user.getCreated();
-        LocalDateTime end = LocalDateTime.now();
-
-        return ResponseEntity.ok(matrixService.matrixRanking(user, start, end));
+        return ResponseEntity.ok(matrixService.matrixRanking(nickname));
     }
 
     @GetMapping("/rank/widen")
-    @Operation(summary = "영역의 수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 영역의 수가 높은 순서대로 유저와 친구들을 조회")
+    @Operation(summary = "영역의 수 랭킹",
+            description = "해당 유저를 기준으로 start-end(기간) 사이 영역의 수가 높은 순서대로 유저와 친구들을 조회\n" +
+            "start: 해당 주 월요일 00시 00분 00초\n" +
+            "end: 해당 주 일요일 23시 59분 59초")
     public ResponseEntity<RankResponseDto.Area> areaRank(@RequestBody UserRequestDto.LookUp requestDto){
         return ResponseEntity.ok(matrixService.areaRanking(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }

--- a/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/controller/MatrixControllerImpl.java
@@ -1,16 +1,16 @@
 package com.dnd.ground.domain.matrix.controller;
 
 import com.dnd.ground.domain.matrix.matrixService.MatrixService;
+import com.dnd.ground.domain.user.User;
 import com.dnd.ground.domain.user.dto.RankResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
+import com.dnd.ground.domain.user.repository.UserRepository;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -20,7 +20,9 @@ import java.time.temporal.TemporalAdjusters;
  * @description 메인홈 구성 컨트롤러 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-02
- * @updated api 명세 수정 - 2022-08-17 박세헌
+ * @updated 1. 역대 누적 칸수 랭킹 구현
+ *          2. nickname, start, end 가진 requestDto 생성
+ *          - 2022-08-18 박세헌
  */
 
 @Api(tags = "운동 영역")
@@ -31,30 +33,22 @@ import java.time.temporal.TemporalAdjusters;
 public class MatrixControllerImpl implements MatrixController {
 
     private final MatrixService matrixService;
+    private final UserRepository userRepository;
 
     @GetMapping("/rank/accumulate")
-    @Operation(summary = "칸의 수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 칸의 수가 높은 순서대로 유저와 친구들을 조회(추후 nickname, start, end를 가진 requestDto 생성 예정)")
-    public ResponseEntity<RankResponseDto.Matrix> matrixRank(@RequestParam("nickname") String nickName){
+    @Operation(summary = "역대 누적 칸의 수 랭킹", description = "해당 유저를 기준으로 가입날짜 ~ 오늘 사이 누적 칸의 수가 높은 순서대로 유저와 친구들을 조회")
+    public ResponseEntity<RankResponseDto.Matrix> matrixRank(@RequestParam("nickname") String nickname){
 
-        /* 추후 nickname, start, end를 가진 requestDto 생성 예정 */
-        LocalDateTime result = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDateTime start = LocalDateTime.of(result.getYear(), result.getMonth(), result.getDayOfMonth(), 0, 0, 0);
+        User user = userRepository.findByNickname(nickname).orElseThrow();
+        LocalDateTime start = user.getCreated();
         LocalDateTime end = LocalDateTime.now();
-        /* 임시로 이번주 기록 조회 */
 
-        return ResponseEntity.ok(matrixService.matrixRanking(nickName, start, end));
+        return ResponseEntity.ok(matrixService.matrixRanking(user, start, end));
     }
 
     @GetMapping("/rank/widen")
-    @Operation(summary = "영역의 수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 영역의 수가 높은 순서대로 유저와 친구들을 조회(추후 nickname, start, end를 가진 requestDto 생성 예정)")
-    public ResponseEntity<RankResponseDto.Area> areaRank(@RequestParam("nickname") String nickName){
-
-        /* 추후 nickname, start, end를 가진 requestDto 생성 예정 */
-        LocalDateTime result = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDateTime start = LocalDateTime.of(result.getYear(), result.getMonth(), result.getDayOfMonth(), 0, 0, 0);
-        LocalDateTime end = LocalDateTime.now();
-        /* 임시로 이번주 기록 조회 */
-
-        return ResponseEntity.ok(matrixService.areaRanking(nickName, start, end));
+    @Operation(summary = "영역의 수 랭킹", description = "해당 유저를 기준으로 start-end(기간) 사이 영역의 수가 높은 순서대로 유저와 친구들을 조회")
+    public ResponseEntity<RankResponseDto.Area> areaRank(@RequestBody UserRequestDto.LookUp requestDto){
+        return ResponseEntity.ok(matrixService.areaRanking(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }
 }

--- a/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixService.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixService.java
@@ -14,13 +14,13 @@ import java.util.List;
  * @description 운동 영역 서비스 인터페이스
  * @author  박세헌
  * @since   2022-08-01
- * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ * @updated matrixRanking함수 파라미터 변경
  *          - 2022.08.18 박세헌
  */
 
 public interface MatrixService {
     Matrix save(Matrix matrix);
-    RankResponseDto.Matrix matrixRanking(User user, LocalDateTime start, LocalDateTime end);
+    RankResponseDto.Matrix matrixRanking(String nickname);
     RankResponseDto.Area areaRanking(String nickname, LocalDateTime start, LocalDateTime end);
     RankResponseDto.Area challengeRank(Challenge challenge, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixService.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixService.java
@@ -14,13 +14,13 @@ import java.util.List;
  * @description 운동 영역 서비스 인터페이스
  * @author  박세헌
  * @since   2022-08-01
- * @updated 1. 랭킹 계산 메소드 모듈화
- *          - 2022.08.17 박찬호
+ * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ *          - 2022.08.18 박세헌
  */
 
 public interface MatrixService {
     Matrix save(Matrix matrix);
-    RankResponseDto.Matrix matrixRanking(String nickname, LocalDateTime start, LocalDateTime end);
+    RankResponseDto.Matrix matrixRanking(User user, LocalDateTime start, LocalDateTime end);
     RankResponseDto.Area areaRanking(String nickname, LocalDateTime start, LocalDateTime end);
     RankResponseDto.Area challengeRank(Challenge challenge, LocalDateTime start, LocalDateTime end);
 

--- a/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixServiceImpl.java
@@ -16,9 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.Tuple;
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -27,7 +25,7 @@ import java.util.Objects;
  * @description 운동 영역 서비스 클래스
  * @author  박세헌
  * @since   2022-08-01
- * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ * @updated matrixRanking함수 파라미터 변경
  *          - 2022.08.18 박세헌
  */
 
@@ -47,12 +45,17 @@ public class MatrixServiceImpl implements MatrixService {
     }
 
     // 랭킹 조회(역대 누적 칸의 수 기준)
-    public RankResponseDto.Matrix matrixRanking(User user, LocalDateTime start, LocalDateTime end) {
+    public RankResponseDto.Matrix matrixRanking(String nickname) {
+        User user = userRepository.findByNickname(nickname).orElseThrow();
         List<User> userAndFriends = friendService.getFriends(user);  // 친구들 조회
         userAndFriends.add(0, user);  // 유저 추가
 
+        LocalDateTime start = user.getCreated();
+        LocalDateTime end = LocalDateTime.now();
+
         // [Tuple(닉네임, 이번주 누적 칸수)] 칸수 기준 내림차순 정렬
         List<Tuple> matrixCount = exerciseRecordRepository.findMatrixCount(userAndFriends, start, end);
+        System.out.println(matrixCount.size());
 
         // 랭킹 계산[랭킹, 닉네임, 칸의 수]
         List<UserResponseDto.Ranking> matrixRankings = calculateMatrixRank(matrixCount, userAndFriends);
@@ -64,6 +67,7 @@ public class MatrixServiceImpl implements MatrixService {
     public RankResponseDto.Area areaRanking(String nickname, LocalDateTime start, LocalDateTime end) {
         User user = userRepository.findByNickname(nickname).orElseThrow();
         List<User> friends = friendService.getFriends(user);  // 친구들 조회
+        System.out.println(friends.size());
         List<UserResponseDto.Ranking> areaRankings = new ArrayList<>();  // [랭킹, 닉네임, 영역의 수]
 
         // 유저의 닉네임과 영역의 수 대입

--- a/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/matrix/matrixService/MatrixServiceImpl.java
@@ -16,7 +16,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.Tuple;
+import java.time.DayOfWeek;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -25,8 +27,8 @@ import java.util.Objects;
  * @description 운동 영역 서비스 클래스
  * @author  박세헌
  * @since   2022-08-01
- * @updated 1. 랭킹 계산 메소드 모듈화
- *          - 2022.08.17 박찬호
+ * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ *          - 2022.08.18 박세헌
  */
 
 @Service
@@ -44,9 +46,8 @@ public class MatrixServiceImpl implements MatrixService {
         return matrixRepository.save(matrix);
     }
 
-    // 랭킹 조회(누적 칸의 수 기준)(보류)
-    public RankResponseDto.Matrix matrixRanking(String nickname, LocalDateTime start, LocalDateTime end) {
-        User user = userRepository.findByNickname(nickname).orElseThrow();
+    // 랭킹 조회(역대 누적 칸의 수 기준)
+    public RankResponseDto.Matrix matrixRanking(User user, LocalDateTime start, LocalDateTime end) {
         List<User> userAndFriends = friendService.getFriends(user);  // 친구들 조회
         userAndFriends.add(0, user);  // 유저 추가
 

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
@@ -2,21 +2,19 @@ package com.dnd.ground.domain.user.controller;
 
 import com.dnd.ground.domain.exerciseRecord.dto.RecordResponseDto;
 import com.dnd.ground.domain.user.dto.ActivityRecordResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
 import com.dnd.ground.domain.user.dto.UserResponseDto;
 import io.swagger.annotations.ApiParam;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * @description 회원 관련 역할 분리 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-02
- * @updated 1. 친구 프로필 조회 기능 구현
- *          - 2022.08.16 박찬호
- *          2. 활동 기록 조회 기능 구현
- *          3. 운동 기록에 대한 정보 조회 기능 구현
- *          4. 상세 지도 보기 기능 구현
- *          - 2022.08.17 박세헌
+ * @updated nickname, start, end 가진 requestDto 생성
+ *         - 2022-08-18 박세헌
  */
 
 public interface UserController {
@@ -26,7 +24,7 @@ public interface UserController {
             @ApiParam(value = "회원 닉네임", required = true) @RequestParam("user") String userNickname,
             @ApiParam(value = "대상 닉네임", required = true) @RequestParam("friend") String friendNickname);
 
-    ResponseEntity<ActivityRecordResponseDto> getActivityRecord(@RequestParam("nickname") String nickname);
+    ResponseEntity<ActivityRecordResponseDto> getActivityRecord(@RequestBody UserRequestDto.LookUp requestDto);
 
     ResponseEntity<RecordResponseDto.EInfo> getRecordInfo(@RequestParam("recordId") Long recordId);
 

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
@@ -3,6 +3,7 @@ package com.dnd.ground.domain.user.controller;
 import com.dnd.ground.domain.exerciseRecord.dto.RecordResponseDto;
 import com.dnd.ground.domain.user.dto.ActivityRecordResponseDto;
 import com.dnd.ground.domain.user.dto.HomeResponseDto;
+import com.dnd.ground.domain.user.dto.UserRequestDto;
 import com.dnd.ground.domain.user.dto.UserResponseDto;
 import com.dnd.ground.domain.user.service.UserService;
 import io.swagger.annotations.Api;
@@ -11,10 +12,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -24,13 +22,8 @@ import java.time.temporal.TemporalAdjusters;
  * @description 회원 관련 컨트롤러 구현체
  * @author  박세헌, 박찬호
  * @since   2022-08-02
- * @updated 1. 친구 프로필 조회 기능 구현
- *          - 2022.08.16 박찬호
- *          2. 활동 기록 조회 기능 구현
- *          3. 운동 기록에 대한 정보 조회 기능 구현
- *          4. 상세 지도 보기 기능 구현
- *          5. api 명세 수정
- *          - 2022.08.17 박세헌
+ * @updated nickname, start, end 가진 requestDto 생성
+ *          - 2022-08-18 박세헌
  */
 
 @Api(tags = "유저")
@@ -67,16 +60,9 @@ public class UserControllerImpl implements UserController {
     }
 
     @GetMapping("/info/activity")
-    @Operation(summary = "나의 활동 기록 조회", description = "해당 유저의 start-end(기간) 사이 활동기록 조회(추후 nickname, start, end를 가진 requestDto 생성 예정)")
-    public ResponseEntity<ActivityRecordResponseDto> getActivityRecord(@RequestParam("nickname") String nickname){
-
-        /* 추후 nickname, start, end를 가진 requestDto 생성 예정 */
-        LocalDateTime result = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-        LocalDateTime start = LocalDateTime.of(result.getYear(), result.getMonth(), result.getDayOfMonth(), 0, 0, 0);
-        LocalDateTime end = LocalDateTime.now();
-        /* 임시로 이번주 기록 */
-
-        return ResponseEntity.ok().body(userService.getActivityRecord(nickname, start, end));
+    @Operation(summary = "나의 활동 기록 조회", description = "해당 유저의 start-end(기간) 사이 활동기록 조회")
+    public ResponseEntity<ActivityRecordResponseDto> getActivityRecord(@RequestBody UserRequestDto.LookUp requestDto){
+        return ResponseEntity.ok().body(userService.getActivityRecord(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }
 
     @GetMapping("/info/activity/record")

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
@@ -37,8 +37,8 @@ public class UserControllerImpl implements UserController {
 
     @GetMapping("/home")
     @Operation(summary = "홈 화면 조회",
-            description = "닉네임을 통해 홈화면에 필요한 유저 정보(userMatrices), " +
-                    "나와 챌린지를 안하는 친구 정보(friendMatrices, 리스트), " +
+            description = "닉네임을 통해 홈화면에 필요한 유저 정보(userMatrices)\n" +
+                    "나와 챌린지를 안하는 친구 정보(friendMatrices, 리스트)\n" +
                     "나와 챌린지를 하는 유저 정보(challengeMatrices, 리스트) 조회")
     public ResponseEntity<HomeResponseDto> home(@RequestParam("nickname") String nickName){
         return ResponseEntity.ok(userService.showHome(nickName));
@@ -60,7 +60,10 @@ public class UserControllerImpl implements UserController {
     }
 
     @GetMapping("/info/activity")
-    @Operation(summary = "나의 활동 기록 조회", description = "해당 유저의 start-end(기간) 사이 활동기록 조회")
+    @Operation(summary = "나의 활동 기록 조회",
+            description = "해당 유저의 start-end(기간) 사이 활동기록 조회\n" +
+                    "start: 해당 날짜의 00시 00분 00초\n" +
+                    "end: 해당 날짜의 23시 59분 59초")
     public ResponseEntity<ActivityRecordResponseDto> getActivityRecord(@RequestBody UserRequestDto.LookUp requestDto){
         return ResponseEntity.ok().body(userService.getActivityRecord(requestDto.getNickname(), requestDto.getStart(), requestDto.getEnd()));
     }

--- a/src/main/java/com/dnd/ground/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/UserRequestDto.java
@@ -1,0 +1,24 @@
+package com.dnd.ground.domain.user.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * @description 회원 관련 Request Dto
+ * @author  박세헌, 박찬호
+ * @since   2022-08-18
+ * @updated nickname, start, end 가진 requestDto 생성
+ *          - 2022-08-18 박세헌
+ */
+
+@Data
+public class UserRequestDto {
+
+    @Data
+    static public class LookUp{
+        private String nickname;
+        private LocalDateTime start;
+        private LocalDateTime end;
+    }
+}

--- a/src/main/java/com/dnd/ground/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/UserRequestDto.java
@@ -1,5 +1,7 @@
 package com.dnd.ground.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -17,8 +19,16 @@ public class UserRequestDto {
 
     @Data
     static public class LookUp{
+
+        @ApiModelProperty(name = "유저의 닉네임", example = "NickA")
         private String nickname;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        @ApiModelProperty(name = "조회 하고 싶은 데이터의 시작 날짜", example = "2022-08-15T00:00:00")
         private LocalDateTime start;
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        @ApiModelProperty(name = "조회 하고 싶은 데이터의 끝 날짜", example = "2022-08-18T23:59:59")
         private LocalDateTime end;
     }
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
@@ -34,7 +34,7 @@ import java.util.*;
  * @description 유저 서비스 클래스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ * @updated matrixRanking함수 파라미터 변경
  *          - 2022.08.18 박세헌
  */
 
@@ -189,7 +189,7 @@ public class UserServiceImpl implements UserService{
         Long allMatrixNumber = -1L;
         Long areas = -1L;
 
-        RankResponseDto.Matrix matrixRanking = matrixService.matrixRanking(friend, friend.getCreated(), LocalDateTime.now());
+        RankResponseDto.Matrix matrixRanking = matrixService.matrixRanking(friendNickname);
 
         //역대 누적 칸수 및 랭킹 정보
         for (UserResponseDto.Ranking allRankInfo: matrixRanking.getMatrixRankings()) {

--- a/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
@@ -34,7 +34,8 @@ import java.util.*;
  * @description 유저 서비스 클래스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated matrixRanking함수 파라미터 변경
+ * @updated 1. matrixRanking함수 파라미터 변경
+ *          2. 활동 기록의 운동 시간 1분 미만 이면 초로 변환
  *          - 2022.08.18 박세헌
  */
 
@@ -236,8 +237,14 @@ public class UserServiceImpl implements UserService{
 
             // 운동 시간 formatting
             Integer exerciseTime = exerciseRecord.getExerciseTime();
-            int minute = exerciseTime / 60;
-            String time = Integer.toString(minute) + "분";
+            String time = "";
+            System.out.println(exerciseTime);
+            if (exerciseTime < 60){
+                time = Integer.toString(exerciseTime) + "초";
+            }
+            else{
+                time = Integer.toString(exerciseTime / 60) + "분";
+            }
 
             activityRecords.add(RecordResponseDto.activityRecord
                     .builder()
@@ -273,8 +280,9 @@ public class UserServiceImpl implements UserService{
         ExerciseRecord exerciseRecord = exerciseRecordRepository.findById(exerciseId).orElseThrow();  // 예외 처리
 
         // 운동 시작, 끝 시간 formatting
-        String started = exerciseRecord.getStarted().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일 HH:mm"));
-        String ended = exerciseRecord.getEnded().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일 HH:mm"));
+        String date = exerciseRecord.getStarted().format(DateTimeFormatter.ofPattern("MM월 dd일 E요일"));
+        String started = exerciseRecord.getStarted().format(DateTimeFormatter.ofPattern("HH:mm"));
+        String ended = exerciseRecord.getEnded().format(DateTimeFormatter.ofPattern("HH:mm"));
 
         // 운동 시간 formatting
         Integer exerciseTime = exerciseRecord.getExerciseTime();
@@ -285,6 +293,7 @@ public class UserServiceImpl implements UserService{
         return RecordResponseDto.EInfo
                 .builder()
                 .recordId(exerciseRecord.getId())
+                .date(date)
                 .started(started)
                 .ended(ended)
                 .matrixNumber((long) exerciseRecord.getMatrices().size())

--- a/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
@@ -34,7 +34,8 @@ import java.util.*;
  * @description 유저 서비스 클래스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated 운동 시작, 끝, 시간 formatting - 202.08.17 박세헌
+ * @updated matrixRanking함수 파라미터 변경(nickname -> user)
+ *          - 2022.08.18 박세헌
  */
 
 @Slf4j
@@ -188,7 +189,7 @@ public class UserServiceImpl implements UserService{
         Long allMatrixNumber = -1L;
         Long areas = -1L;
 
-        RankResponseDto.Matrix matrixRanking = matrixService.matrixRanking(friendNickname, friend.getCreated(), LocalDateTime.now());
+        RankResponseDto.Matrix matrixRanking = matrixService.matrixRanking(friend, friend.getCreated(), LocalDateTime.now());
 
         //역대 누적 칸수 및 랭킹 정보
         for (UserResponseDto.Ranking allRankInfo: matrixRanking.getMatrixRankings()) {


### PR DESCRIPTION
1. nickname, start. end를 가진 requestDto 생성
2. 역대 누적 랭킹 조회 기능 구현
3. 운동 시간 관련 포매팅 수정(활동내역에서 운동시간 1분 미만시 초로 response)