### PR TITLE
FEAT: 카카오 API 관련 기능 구현 등

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 logs/
 application-dev.properties
 application-production.properties
+aws.yml

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	//UUID
 	implementation "com.fasterxml.uuid:java-uuid-generator:4.0.1"
 
+	//AWS S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 	//AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
 
+	//WebClient (HTTP Request)
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dnd/ground/domain/user/User.java
+++ b/src/main/java/com/dnd/ground/domain/user/User.java
@@ -17,8 +17,10 @@ import java.util.List;
  * @description 회원 엔티티
  * @author  박찬호, 박세헌
  * @since   2022.07.28
- * @updated 1. 유저 프로필 수정 비즈니스 로직 추가
- *           - 2022-08-19 박세헌헌 */
+ * @updated 1. 카카오 회원 번호 필드 추가
+ *          2. 프로필 사진 관련 필드 주석 처리
+ *           - 2022-08-23 박찬호
+ */
 
 @Getter
 @Builder
@@ -31,6 +33,9 @@ public class User {
     @Id @GeneratedValue
     @Column(name = "user_id")
     private Long id;
+
+    @Column(name = "kakao_id")
+    private Long kakaoId;
 
     @Column(name = "username", nullable = false)
     private String username;
@@ -62,6 +67,12 @@ public class User {
 
     @Column(name="is_public_record", nullable = false)
     private Boolean isPublicRecord;
+
+//    @Column(name="picture_name", nullable = false)
+//    private String pictureName;
+//
+//    @Column(name="picture_path", nullable = false)
+//    private String picturePath;
 
     @OneToMany(mappedBy = "friend")
     private List<Friend> friends = new ArrayList<>();

--- a/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.dnd.ground.domain.user.controller;
+
+import com.dnd.ground.domain.user.service.KakaoService;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @description 회원 정보와 관련한 컨트롤러
+ * @author  박찬호
+ * @since   2022-08-23
+ * @updated 1. 컨트롤러 생성 생성
+ *          - 2022.08.23 박찬호
+ */
+
+@Api(tags = "회원 인증/인가")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping("/auth/kakao/login")
+    @Operation(summary = "카카오 토큰 발급", description = "인가코드를 활용한 카카오 토큰 발급(엑세스, 리프레시)")
+    public ResponseEntity<?> kakaoLogin(@RequestParam("code") String code) {
+        return kakaoService.kakaoLogin(code);
+    }
+}

--- a/src/main/java/com/dnd/ground/domain/user/dto/KakaoDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/KakaoDto.java
@@ -1,0 +1,53 @@
+package com.dnd.ground.domain.user.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import java.util.Map;
+
+/**
+ * @description 카카오 API를 사용할 때 필요한 DTO
+ * @author  박찬호
+ * @since   2022-08-23
+ * @updated 1. DTO 생성
+ *          - 2022.08.23 박찬호
+ */
+
+@Data
+public class KakaoDto {
+
+    /*카카오에게 받은 토큰*/
+    @Data
+    public static class Token {
+        @ApiModelProperty(value="카카오로부터 받은 엑세스 토큰", example="vXezXAmm8Yj2frWVLofx_4v4c9EOwfaAokojr1c2Cj11mgAAAYLKLqJr")
+        private String access_token;
+
+        @ApiModelProperty(value="카카오로부터 받은 리프레시 토큰", example="2LqQd2jnW50rHbOyGyyKu_xNRv4p2Jri7wWsso7RCj11mgAAAYLKLqJq")
+        private String refresh_token;
+    }
+
+    /*토큰 정보*/
+    @Data
+    public static class TokenInfo {
+        @ApiModelProperty(value="카카오 회원 번호(우리 회원 번호X)", example="2399961704")
+        private Long id;
+
+        @ApiModelProperty(value="토큰 만료까지 남은 시간(단위:초)", example="21599")
+        private Integer expires_in;
+
+        @ApiModelProperty(value="카카오에서의 우리 서비스 번호", example="788508")
+        private Integer app_id;
+    }
+
+    @Data
+    public static class UserInfo {
+        @ApiModelProperty(value="카카오 회원 번호(우리 회원 번호X)", example="2399961704")
+        private Long id;
+
+        @ApiModelProperty(value="이메일(테스트 안해본 상태)", example="koc081900@naver.com")
+        private String email;
+
+        @ApiModelProperty(value="사용자 정보(프로필 사진 관련)", example="{\"profile_image\":\"http://k.kakaocdn.net/dn/3O7st/btrHep5Sa9R/4lxH3JhkeZyqK0KFB1XoGk/img_640x640.jpg\",\"thumbnail_image\":\"http://k.kakaocdn.net/dn/3O7st/btrHep5Sa9R/4lxH3JhkeZyqK0KFB1XoGk/img_110x110.jpg\"}")
+        private Map<String, String> properties;
+    }
+}

--- a/src/main/java/com/dnd/ground/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd/ground/domain/user/repository/UserRepository.java
@@ -10,9 +10,10 @@ import java.util.Optional;
 
 /**
  * @description 유저 리포지토리 인터페이스
- * @author  박세헌
+ * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated 2022-08-17 / 운동기록을 통해 유저 조회 - 박세헌
+ * @updated 1. 카카오 회원 번호로 회원 조회 쿼리 추가
+ *          2022-08-23 박찬호
  */
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -21,5 +22,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u join u.exerciseRecords e where e = :exerciseRecord")
     Optional<User> findByExerciseRecord(ExerciseRecord exerciseRecord);
+
+    Optional<User> findByKakaoId(Long id);
 
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/KakaoService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/KakaoService.java
@@ -65,12 +65,8 @@ public class KakaoService {
                 .bodyToMono(KakaoDto.Token.class)
                 .block();
 
-        System.out.println("토큰: " + token.toString());
-
         //카카오 토큰 정보 보기 API 호출
         KakaoDto.TokenInfo tokenInfo = getTokenInfo(token.getAccess_token());
-
-        System.out.println("**토큰정보: " + tokenInfo.toString());
 
         //기존 유저 → 200 Status + 닉네임
         Optional<User> user = userRepository.findByKakaoId(tokenInfo.getId());

--- a/src/main/java/com/dnd/ground/domain/user/service/KakaoService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/KakaoService.java
@@ -1,0 +1,105 @@
+package com.dnd.ground.domain.user.service;
+
+import com.dnd.ground.domain.user.User;
+import com.dnd.ground.domain.user.dto.KakaoDto;
+import com.dnd.ground.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import javax.annotation.PostConstruct;
+import java.util.Optional;
+
+/**
+ * @description 카카오와 관련한 서비스 클래스
+ * @author  박찬호
+ * @since   2022-08-23
+ * @updated 1. 인가 코드를 활용한 엑세스 토큰 발급 및 신규 회원 구분 API 구현
+ *          2. 엑세스 토큰 정보 확인 API 구현
+ *          3. 엑세스 토큰을 활용한 사용자 정보 확인 API 구현
+ *
+ *          **각 API 호출에 대한 NPE 처리 필요
+ *          - 2022.08.23 박찬호
+ */
+
+@RequiredArgsConstructor
+@Service
+public class KakaoService {
+
+    private final UserRepository userRepository;
+    WebClient webClient;
+
+    @Value("${kakao.REST_KEY}")
+    private String REST_API_KEY;
+
+    /*로컬과 배포 환경의 Redirect URI가 다른 점 확인!*/
+    @Value("${kakao.REDIRECT_URI}")
+    private String REDIRECT_URI;
+
+    @PostConstruct
+    public void initWebClient() {
+        webClient = WebClient.create();
+    }
+
+    public ResponseEntity<?> kakaoLogin(String code)  {
+        //토큰을 받기 위한 HTTP Body 생성
+        MultiValueMap<String, String> getTokenBody = new LinkedMultiValueMap<>();
+        getTokenBody.add("grant_type", "authorization_code");
+        getTokenBody.add("client_id", REST_API_KEY);
+        getTokenBody.add("redirect_uri", REDIRECT_URI);
+        getTokenBody.add("code", code);
+
+        //카카오 토큰 발급 API 호출
+        KakaoDto.Token token = webClient.post()
+                .uri("https://kauth.kakao.com/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(getTokenBody))
+                .retrieve()
+                .bodyToMono(KakaoDto.Token.class)
+                .block();
+
+        System.out.println("토큰: " + token.toString());
+
+        //카카오 토큰 정보 보기 API 호출
+        KakaoDto.TokenInfo tokenInfo = getTokenInfo(token.getAccess_token());
+
+        System.out.println("**토큰정보: " + tokenInfo.toString());
+
+        //기존 유저 → 200 Status + 닉네임
+        Optional<User> user = userRepository.findByKakaoId(tokenInfo.getId());
+        if (user.isPresent()) {
+            return ResponseEntity.status(HttpStatus.OK).body(user.get().getNickname());
+        }
+        //신규 유저 → 201 Status + 토큰
+        else {
+            return ResponseEntity.status(HttpStatus.CREATED).body(token);
+        }
+    }
+
+    /*카카오 엑세스 토큰 정보 확인*/
+    public KakaoDto.TokenInfo getTokenInfo(String token) {
+        return webClient.get()
+                .uri("https://kapi.kakao.com/v1/user/access_token_info")
+                .header("Authorization","Bearer " + token)
+                .retrieve()
+                .bodyToMono(KakaoDto.TokenInfo.class)
+                .block();
+    }
+
+    /*사용자 정보 확인*/
+    public KakaoDto.UserInfo getUserInfo(String token) {
+        return webClient.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .header("Authorization", "Bearer " + token)
+                .retrieve()
+                .bodyToMono(KakaoDto.UserInfo.class)
+                .block();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,7 @@ logging:
   level:
     org.hibernate.SQL: debug
     org.hibernate.type: trace
+
+kakao:
+  REST_KEY: ${kakao.REST_KEY}
+  REDIRECT_URI: ${kakao.REDIRECT_URI}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,16 +1,16 @@
 -- 회원 생성
-insert into user values(1,"2022-08-01 01:00", "A-Intro", true, true, true, 37.330436, -122.030216, "A-mail@gmail.com", "NickA", "UserA");
-insert into user values(2,"2022-08-02 02:00", "B-Intro", true, true, true, 37.331184, -122.02311, "B-mail@naver.com", "NickB", "UserB");
-insert into user values(3,"2022-08-03 03:00", "C-Intro", true, true, true, 37.337542, -122.036574, "C-mail@daum.com", "NickC", "UserC");
+insert into user values(1,"2022-08-01 01:00", "A-Intro", true, true, true, 123456, 37.330436, -122.030216, "A-mail@gmail.com", "NickA", "UserA");
+insert into user values(2,"2022-08-02 02:00", "B-Intro", true, true, true, 123456, 37.331184, -122.02311, "B-mail@naver.com", "NickB", "UserB");
+insert into user values(3,"2022-08-03 03:00", "C-Intro", true, true, true, 123456, 37.337542, -122.036574, "C-mail@daum.com", "NickC", "UserC");
 
-insert into user values(4,"2022-08-04 04:00", "D-Intro", true, true, true, 37.337542, -122.038444, "D-mail@gmail.com", "NickD", "UserD");
-insert into user values(5,"2022-08-05 05:00", "E-Intro", true, true, true, 37.337542, -122.041062, "E-mail@dnd.com", "NickE", "UserE");
+insert into user values(4,"2022-08-04 04:00", "D-Intro", true, true, true, 123456, 37.337542, -122.038444, "D-mail@gmail.com", "NickD", "UserD");
+insert into user values(5,"2022-08-05 05:00", "E-Intro", true, true, true, 123456, 37.337542, -122.041062, "E-mail@dnd.com", "NickE", "UserE");
 
-insert into user values(6,"2022-08-06 06:00", "F-Intro", true, true, true, 37.337542, -122.041062, "F-mail@gmail.com", "NickF", "UserF");
-insert into user values(7,"2022-08-07 07:00", "G-Intro", true, true, true, 37.337542, -122.041062, "G-mail@naver.com", "NickG", "UserG");
+insert into user values(6,"2022-08-06 06:00", "F-Intro", true, true, true, 123456, 37.337542, -122.041062, "F-mail@gmail.com", "NickF", "UserF");
+insert into user values(7,"2022-08-07 07:00", "G-Intro", true, true, true, 123456, 37.337542, -122.041062, "G-mail@naver.com", "NickG", "UserG");
 
-insert into user values(8,"2022-08-08 08:00", "H-Intro", true, true, true, 37.337542, -122.041062, "H-mail@dnd.com", "NickH", "UserH");
-insert into user values(9,"2022-08-09 09:00", "I-Intro", true, true, true, 37.337542, -122.041062, "I-mail@daum.com", "NickI", "UserI");
+insert into user values(8,"2022-08-08 08:00", "H-Intro", true, true, true, 123456, 37.337542, -122.041062, "H-mail@dnd.com", "NickH", "UserH");
+insert into user values(9,"2022-08-09 09:00", "I-Intro", true, true, true, 123456, 37.337542, -122.041062, "I-mail@daum.com", "NickI", "UserI");
 
 -- 친구 관계 생성
 -- A-B-C는 서로 친구 관계
@@ -32,9 +32,9 @@ insert into friend values(7, "Wait", 6, 7);
 insert into friend values(8, "Reject", 8, 9);
 
 -- 챌린지 정보
-insert into challenge values(1, "2022-08-15", "챌린지1의 신청 메시지", "챌린지1", "2022-08-16", "Progress", "Widen", "11ed1e26d25aa6b4b02fbb2d0e652b0f");
-insert into challenge values(2, "2022-08-15", "챌린지2의 신청 메시지", "챌린지2", "2022-08-16", "Progress", "Accumulate", "11ed1e42ae1af37a895b2f2416025f66");
-insert into challenge values(3, "2022-08-15", "챌린지3의 신청 메시지", "챌린지3", "2022-08-16", "Progress", "Widen", "11ed1e42ae5febbb895bf3c6f08ac475");
+insert into challenge values(1, "2022-08-22", "챌린지1의 신청 메시지", "챌린지1", "2022-08-23", "Progress", "Widen", "11ed1e26d25aa6b4b02fbb2d0e652b0f");
+insert into challenge values(2, "2022-08-22", "챌린지2의 신청 메시지", "챌린지2", "2022-08-23", "Progress", "Accumulate", "11ed1e42ae1af37a895b2f2416025f66");
+insert into challenge values(3, "2022-08-22", "챌린지3의 신청 메시지", "챌린지3", "2022-08-23", "Progress", "Widen", "11ed1e42ae5febbb895bf3c6f08ac475");
 
 -- 챌린지에 참여하는 회원 정보
 insert into user_challenge values(1, "Red", "Progress", 1, 1);
@@ -47,17 +47,17 @@ insert into user_challenge values(5, "Yellow", "Progress", 3, 1);
 insert into user_challenge values(6, "Red", "Progress", 3, 4);
 
 -- 운동 기록 정보
-insert into exercise_record values(1, 3000, "2022-08-16 18:00", 1800, "A의 첫 번째 운동기록", "2022-08-16 17:30", 5000, 1);
-insert into exercise_record values(2, 5000, "2022-08-16 13:00", 3600, "A의 두 번째 운동기록", "2022-08-16 12:00", 10000, 1);
+insert into exercise_record values(1, 3000, "2022-08-23 18:00", 1800, "A의 첫 번째 운동기록", "2022-08-23 17:30", 5000, 1);
+insert into exercise_record values(2, 5000, "2022-08-23 13:00", 3600, "A의 두 번째 운동기록", "2022-08-23 12:00", 10000, 1);
 
-insert into exercise_record values(3, 1500, "2022-08-16 15:00", 7200, "B의 운동기록", "2022-08-16 13:00", 2500, 2);
+insert into exercise_record values(3, 1500, "2022-08-23 15:00", 7200, "B의 운동기록", "2022-08-23 13:00", 2500, 2);
 
-insert into exercise_record values(4, 2000, "2022-08-16 22:10", 600, "C의 운동기록", "2022-08-16 22:00", 1000, 3);
+insert into exercise_record values(4, 2000, "2022-08-23 22:10", 600, "C의 운동기록", "2022-08-23 22:00", 1000, 3);
 
-insert into exercise_record values(5, 500, "2022-08-15 22:05", 300, "D의 첫 번째 운동기록", "2022-08-15 22:00", 550, 4);
-insert into exercise_record values(6, 1000, "2022-08-16 00:15", 900, "D의 두 번째 운동기록", "2022-08-16 00:00", 1100, 4);
+insert into exercise_record values(5, 500, "2022-08-22 22:05", 300, "D의 첫 번째 운동기록", "2022-08-23 22:00", 550, 4);
+insert into exercise_record values(6, 1000, "2022-08-23 00:15", 900, "D의 두 번째 운동기록", "2022-08-23 00:00", 1100, 4);
 
-insert into exercise_record values(7, 6000, "2022-08-16 10:30", 3600, "E의 운동기록", "2022-08-16 10:00", 15000, 5);
+insert into exercise_record values(7, 6000, "2022-08-23 10:30", 3600, "E의 운동기록", "2022-08-23 10:00", 15000, 5);
 
 -- 영역 정보
 insert into matrix values(1, 37.331558, -122.030216, 1);


### PR DESCRIPTION
1. 인가코드를 활용해 카카오 엑세스 토큰 발급 API 구현
2. DB에 저장된 회원의 카카오 회원 번호를 통해 신규/기존 회원 구분
3. 엑세스 토큰 정보 조회 API 구현
4. 엑세스 토큰을 통한 사용자 정보 조회 API 구현
5. HTTP Request를 위한 WebClient 의존성 추가
6. User 엔티티 변경에 따른 data.sql 수정
7. 카카오 관련 설정(REST API KEY, REDIRECT URL) 추가