### PR TITLE
[FEAT] JWT 토큰을 관련 로직 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,12 @@ dependencies {
 	//WebClient (HTTP Request)
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// JAVA JWT
+	implementation("com.auth0:java-jwt:3.16.0")
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/dnd/ground/domain/user/User.java
+++ b/src/main/java/com/dnd/ground/domain/user/User.java
@@ -3,6 +3,7 @@ package com.dnd.ground.domain.user;
 import com.dnd.ground.domain.challenge.UserChallenge;
 import com.dnd.ground.domain.exerciseRecord.ExerciseRecord;
 import com.dnd.ground.domain.friend.Friend;
+import com.dnd.ground.domain.user.dto.JwtUserDto;
 import lombok.*;
 import org.springframework.http.HttpStatus;
 
@@ -17,9 +18,8 @@ import java.util.List;
  * @description 회원 엔티티
  * @author  박찬호, 박세헌
  * @since   2022.07.28
- * @updated 1. 카카오 회원 번호 필드 추가
- *          2. 프로필 사진 관련 필드 주석 처리
- *           - 2022-08-23 박찬호
+ * @updated 1. 리프레시 토큰 필드 생성 및 비즈니스 로직 추가
+ *          - 2022-08-24 박세헌
  */
 
 @Getter
@@ -74,6 +74,9 @@ public class User {
 //    @Column(name="picture_path", nullable = false)
 //    private String picturePath;
 
+    @Column(name="refresh_token")
+    private String refreshToken;
+
     @OneToMany(mappedBy = "friend")
     private List<Friend> friends = new ArrayList<>();
 
@@ -109,4 +112,9 @@ public class User {
         this.nickname = nickname;
         this.intro = intro;
     }
+
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
+
 }

--- a/src/main/java/com/dnd/ground/domain/user/dto/JwtUserDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/JwtUserDto.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class JwtUserDto {
-    private Long Id;  // 카카오 id
+    private Long id;  // 카카오 id
     private String username;
     private String nickname;
     private String mail;

--- a/src/main/java/com/dnd/ground/domain/user/dto/JwtUserDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/JwtUserDto.java
@@ -1,0 +1,26 @@
+package com.dnd.ground.domain.user.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @description 카카오 정보를 받기 위한 dto
+ * @author  박세헌
+ * @since   2022-08-24
+ * @updated dto 생성
+ *          - 2022.08.24 박세헌
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JwtUserDto {
+    private Long Id;  // 카카오 id
+    private String username;
+    private String nickname;
+    private String mail;
+}

--- a/src/main/java/com/dnd/ground/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd/ground/domain/user/repository/UserRepository.java
@@ -12,8 +12,8 @@ import java.util.Optional;
  * @description 유저 리포지토리 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated 1. 카카오 회원 번호로 회원 조회 쿼리 추가
- *          2022-08-23 박찬호
+ * @updated 1. 카카오 id를 통해 유저가 존재하는지 확인하는 함수
+ *            - 2022-08-24 박세헌
  */
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -24,5 +24,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByExerciseRecord(ExerciseRecord exerciseRecord);
 
     Optional<User> findByKakaoId(Long id);
+
+    Boolean existsByKakaoId(Long id);
 
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserService.java
@@ -4,9 +4,11 @@ import com.dnd.ground.domain.exerciseRecord.dto.RecordResponseDto;
 import com.dnd.ground.domain.user.User;
 import com.dnd.ground.domain.user.dto.ActivityRecordResponseDto;
 import com.dnd.ground.domain.user.dto.HomeResponseDto;
+import com.dnd.ground.domain.user.dto.JwtUserDto;
 import com.dnd.ground.domain.user.dto.UserResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 
@@ -14,13 +16,12 @@ import java.time.LocalDateTime;
  * @description 회원 서비스 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated  1  운동 기록 메시지 수정 기능
- *           2. 회원 프로필 수정 기능
- *           - 2022-08-19 박세헌
+ * @updated loadUserByUsername함수 추가
+ *           - 2022-08-24 박세헌
  */
 
 public interface UserService {
-    User save(User user);
+    User save(JwtUserDto user);
     HomeResponseDto showHome(String nickname);
     UserResponseDto.UInfo getUserInfo(String nickname);
 
@@ -35,4 +36,6 @@ public interface UserService {
 
     ResponseEntity<?> editRecordMessage(Long recordId, String message);
     ResponseEntity<?> editUserProfile(String originNick, String editNick, String intro);
+
+    UserDetails loadUserByUsername(String nickname);
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserServiceImpl.java
@@ -419,7 +419,7 @@ public class UserServiceImpl implements UserService, UserDetailsService {
         return org.springframework.security.core.userdetails.User
                 .builder()
                 .username(nickname)
-                .password(passwordEncoder.encode(user.getKakaoId()+user.getMail()))
+                .password(passwordEncoder.encode(user.getKakaoId()+user.getNickname()))
                 .authorities("BASIC")
                 .build();
     }

--- a/src/main/java/com/dnd/ground/global/config/SpringSecurityConfig.java
+++ b/src/main/java/com/dnd/ground/global/config/SpringSecurityConfig.java
@@ -1,0 +1,73 @@
+package com.dnd.ground.global.config;
+
+import com.dnd.ground.domain.user.repository.UserRepository;
+import com.dnd.ground.domain.user.service.UserService;
+import com.dnd.ground.global.securityFilter.JWTCheckFilter;
+import com.dnd.ground.global.securityFilter.JWTSignFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+
+/**
+ * @description 스프링 시큐리티 config 클래스
+ * @author  박세헌
+ * @since   2022-08-24
+ * @updated 1. 생성
+ *          - 2022-08-24 박세헌
+ */
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SpringSecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    // 패스워드는 BCryptPasswordEncoder로 보안
+    @Bean
+    PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        // 회원가입 or 재로그인 인증 필터
+        JWTSignFilter loginFilter = new JWTSignFilter(authenticationManager(authenticationConfiguration), userService, userRepository);
+        // 매 request마다 토큰을 검사 해주는 필터
+        JWTCheckFilter checkFilter = new JWTCheckFilter(authenticationManager(authenticationConfiguration), userService, userRepository);
+
+        http
+                .csrf().disable()  // csrf x
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)  // 세션 x
+                )
+                .authorizeRequests()
+                .antMatchers("/", "/sign", "/auth/kakao/login").permitAll()  // 누구나 접근 가능
+                .anyRequest().authenticated() // 나머지 요청들은 권한의 종류에 상관 없이 권한이 있어야 접근 가능
+                .and()
+                .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAt(checkFilter, BasicAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/dnd/ground/global/securityFilter/JWTCheckFilter.java
+++ b/src/main/java/com/dnd/ground/global/securityFilter/JWTCheckFilter.java
@@ -51,7 +51,7 @@ public class JWTCheckFilter extends BasicAuthenticationFilter {
                                     FilterChain chain) throws IOException, ServletException {
 
         String accessToken = request.getHeader("access_token");
-        String refreshToken = request.getHeader("access_token");
+        String refreshToken = request.getHeader("refresh_token");
 
         // 왜 토큰이 안오죠? 넘어가
         if (accessToken == null || !accessToken.startsWith("Bearer ")){

--- a/src/main/java/com/dnd/ground/global/securityFilter/JWTCheckFilter.java
+++ b/src/main/java/com/dnd/ground/global/securityFilter/JWTCheckFilter.java
@@ -1,0 +1,100 @@
+package com.dnd.ground.global.securityFilter;
+
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.dnd.ground.domain.user.User;
+import com.dnd.ground.domain.user.repository.UserRepository;
+import com.dnd.ground.domain.user.service.UserService;
+import com.dnd.ground.global.util.JwtUtil;
+import com.dnd.ground.global.util.JwtVerifyResult;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.security.sasl.AuthenticationException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * @description 매 request마다 토큰을 검사해주는 필터
+ * @author  박세헌, 박찬호
+ * @since   2022-08-02
+ * @updated 1. 생성
+ *          - 2022.08.24 박세헌
+ * @note 1. 매 request마다 토큰을 검사하여 securityContestHolder에 채워줌
+ *       2. 해당 필터에서 자동 로그인을 구현 하면 될 것 같음
+ *       (사용자가 어플을 키면 클라에서 토큰과 함께 임의의 uri로 요청을 보내면 되지 않을까..?)
+ */
+
+public class JWTCheckFilter extends BasicAuthenticationFilter {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    public JWTCheckFilter(AuthenticationManager authenticationManager,
+                          UserService userService,
+                          UserRepository userRepository)
+    {
+        super(authenticationManager);
+        this.userService = userService;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain chain) throws IOException, ServletException {
+
+        String accessToken = request.getHeader("access_token");
+        String refreshToken = request.getHeader("access_token");
+
+        // 왜 토큰이 안오죠? 넘어가
+        if (accessToken == null || !accessToken.startsWith("Bearer ")){
+            chain.doFilter(request, response);
+            return;
+        }
+
+        // 액세스 토큰 verify
+        String token = accessToken.substring("Bearer ".length());
+        JwtVerifyResult result = JwtUtil.verify(token);
+
+        // 클라에서 리프레시 토큰이 왔다는건 (액세스토큰은 만료된 것)
+        if (refreshToken != null){
+            // 리프레시 토큰도 만료됐다면
+            if (!JwtUtil.verify(refreshToken.substring("Bearer ".length())).isSuccess()){
+                throw new TokenExpiredException("토큰이 만료되었습니다!"); // 로그인 페이지로 가야해!
+            }
+
+            // 리프레시 토큰이 유효하다면
+            else{
+                User user = userRepository.findByNickname(result.getNickname()).orElseThrow();
+                // 유저의 리프레시 토큰과 넘어온 리프레시 토큰이 같으면
+                if (Objects.equals(user.getRefreshToken(), refreshToken.substring("Bearer ".length()))){
+                    // 토큰 재발급, 리프레시 토큰은 저장
+                    accessToken = JwtUtil.makeAccessToken(result.getNickname());
+                    refreshToken = JwtUtil.makeRefreshToken(result.getNickname());
+                    response.setHeader("aceess_token", "Bearer "+accessToken);
+                    response.setHeader("refresh_token", "Bearer "+refreshToken);
+                    user.updateRefreshToken(refreshToken);
+                    userRepository.save(user);
+                }
+                else{
+                    throw new AuthenticationException("잘못된 토큰 입니다.");
+                }
+            }
+        }
+
+        // 필터 통과
+        UserDetails user = userService.loadUserByUsername(result.getNickname());
+        UsernamePasswordAuthenticationToken userToken = new UsernamePasswordAuthenticationToken(
+                user.getUsername(), user.getPassword(), user.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(userToken);
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
+++ b/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
@@ -1,0 +1,105 @@
+package com.dnd.ground.global.securityFilter;
+
+import com.dnd.ground.domain.user.dto.JwtUserDto;
+import com.dnd.ground.domain.user.repository.UserRepository;
+import com.dnd.ground.domain.user.service.UserService;
+import com.dnd.ground.global.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONObject;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @description 회원가입 혹은 재로그인시 인증 필터
+ * @author  박세헌
+ * @since   2022-08-24
+ * @updated 1. 필터 생성
+ *          - 2022.08.24 박찬호
+ * @note 1. 찬호가 카카오 유저 대한 정보를 JwtUserDto에 맞게 "/sign"으로 post요청(회원가입 or 재로그인)
+ *       2. 기존 유저가 자동 로그인 되는 기능은 어디서 처리? 해당 필터에서 처리 가능 할 것 같지만 매우매우 복잡
+ */
+
+public class JWTSignFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final UserService userService;
+    private final UserRepository userRepository;
+
+    public JWTSignFilter(AuthenticationManager authenticationManager,
+                         UserService userService,
+                         UserRepository userRepository)
+    {
+        super(authenticationManager);
+        this.userService = userService;
+        this.userRepository = userRepository;
+        setFilterProcessesUrl("/sign");
+    }
+
+    // 회원 가입
+    @Override
+    public Authentication attemptAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response) throws AuthenticationException
+    {
+        // 정보를 JwtUSerDto에 저장
+        JwtUserDto userDto = null;
+        try {
+            userDto = objectMapper.readValue(request.getInputStream(), JwtUserDto.class);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // 신규 회원이면 저장
+        if (!userRepository.existsByKakaoId(userDto.getId())){
+            userService.save(userDto);
+        }
+
+        // id: 닉네임, password: kakaoId + mail
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                userDto.getNickname(),
+                userDto.getId()+userDto.getMail(),
+                null
+        );
+
+        // AuthenticationManager에게 인증 요청
+        return getAuthenticationManager().authenticate(token);
+    }
+
+    // 성공적으로 인증이 되었다면 넘어옴 해당 함수로 넘어옴
+    @Override
+    protected void successfulAuthentication(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain,
+            Authentication authResult) throws IOException, ServletException
+    {
+        // 유저 찾아서
+        User principal = (User) authResult.getPrincipal();
+        String accessToken = JwtUtil.makeAccessToken(principal.getUsername());
+        String refreshToken = JwtUtil.makeAccessToken(principal.getUsername());
+
+        // Jwt토큰 발급, refresh 토큰은 저장
+        response.setHeader("aceess_token", "Bearer "+accessToken);
+        response.setHeader("refresh_token", "Bearer "+refreshToken);
+        com.dnd.ground.domain.user.User user = userRepository.findByNickname(principal.getUsername()).orElseThrow();
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        // 닉네임과 함께 response
+        JSONObject json = new JSONObject();
+        json.put("nickname", principal.getUsername());
+        response.getWriter().write(String.valueOf(json));
+    }
+}

--- a/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
+++ b/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
@@ -26,7 +26,8 @@ import java.io.IOException;
  * @author  박세헌
  * @since   2022-08-24
  * @updated 1. 필터 생성
- *          - 2022.08.24 박찬호
+ *          2. password: kakaoId + 닉네임
+ *          - 2022.08.24 박세헌
  * @note 1. 찬호가 카카오 유저 대한 정보를 JwtUserDto에 맞게 "/sign"으로 post요청(회원가입 or 재로그인)
  *       2. 기존 유저가 자동 로그인 되는 기능은 어디서 처리? 해당 필터에서 처리 가능 할 것 같지만 매우매우 복잡
  */
@@ -66,10 +67,10 @@ public class JWTSignFilter extends UsernamePasswordAuthenticationFilter {
             userService.save(userDto);
         }
 
-        // id: 닉네임, password: kakaoId + mail
+        // id: 닉네임, password: kakaoId + 닉네임
         UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
                 userDto.getNickname(),
-                userDto.getId()+userDto.getMail(),
+                userDto.getId()+userDto.getNickname(),
                 null
         );
 

--- a/src/main/java/com/dnd/ground/global/util/JwtUtil.java
+++ b/src/main/java/com/dnd/ground/global/util/JwtUtil.java
@@ -1,0 +1,52 @@
+package com.dnd.ground.global.util;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+;
+import java.time.Instant;
+
+/**
+ * @description JWT 관련 util(토큰 생성, 유효성 검사)
+ * @author  박세헌
+ * @since   2022-08-24
+ * @updated 1. JWT Util 클래스 생성
+ *          - 2022.08.24 박세헌
+ */
+
+public class JwtUtil {
+
+    private static final Algorithm ALGORITHM = Algorithm.HMAC256("token-secret-key");
+    private static final long ACCESS_TIME = 60*30;  // 액세스 토큰 30분
+    private static final long REFRESH_TIME = 60*60*24*14;  // 리프레시 토큰 2주
+
+    // 액세스 토큰 생성
+    public static String makeAccessToken(String name){
+        return JWT.create()
+                .withClaim("exp", Instant.now().getEpochSecond()+ACCESS_TIME)
+                .withSubject(name)
+                .sign(ALGORITHM);
+    }
+
+    // 리프레시 토큰 생성
+    public static String makeRefreshToken(String name){
+        return JWT.create()
+                .withClaim("exp", Instant.now().getEpochSecond()+REFRESH_TIME)
+                .withSubject(name)
+                .sign(ALGORITHM);
+    }
+
+    // 유효성 검사(토큰 subject, 유효성 여부)
+    public static JwtVerifyResult verify(String token){
+        try {
+            DecodedJWT verify = JWT.require(ALGORITHM).build().verify(token);
+            return JwtVerifyResult.builder().success(true)
+                    .nickname(verify.getSubject()).build();
+        } catch (Exception ex){
+            DecodedJWT decode = JWT.decode(token);
+            return JwtVerifyResult.builder().success(false)
+                    .nickname(decode.getSubject()).build();
+        }
+    }
+
+}

--- a/src/main/java/com/dnd/ground/global/util/JwtUtil.java
+++ b/src/main/java/com/dnd/ground/global/util/JwtUtil.java
@@ -17,7 +17,7 @@ import java.time.Instant;
 public class JwtUtil {
 
     private static final Algorithm ALGORITHM = Algorithm.HMAC256("token-secret-key");
-    private static final long ACCESS_TIME = 60*30;  // 액세스 토큰 30분
+    private static final long ACCESS_TIME = 60 * 30;  // 액세스 토큰 30분
     private static final long REFRESH_TIME = 60*60*24*14;  // 리프레시 토큰 2주
 
     // 액세스 토큰 생성

--- a/src/main/java/com/dnd/ground/global/util/JwtVerifyResult.java
+++ b/src/main/java/com/dnd/ground/global/util/JwtVerifyResult.java
@@ -1,0 +1,23 @@
+package com.dnd.ground.global.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @description JWT 유효성 검사 결과 클래스(토큰 subject, 유효성 여부)
+ * @author  박세헌
+ * @since   2022-08-24
+ * @updated 1. 생성
+ *          - 2022.08.24 박세헌
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class JwtVerifyResult {
+    private boolean success;
+    private String nickname;
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,16 +1,16 @@
 -- 회원 생성
-insert into user values(1,"2022-08-01 01:00", "A-Intro", true, true, true, 123456, 37.330436, -122.030216, "A-mail@gmail.com", "NickA", "UserA");
-insert into user values(2,"2022-08-02 02:00", "B-Intro", true, true, true, 123456, 37.331184, -122.02311, "B-mail@naver.com", "NickB", "UserB");
-insert into user values(3,"2022-08-03 03:00", "C-Intro", true, true, true, 123456, 37.337542, -122.036574, "C-mail@daum.com", "NickC", "UserC");
+insert into user values(1,"2022-08-01 01:00", "A-Intro", true, true, true, 123456, 37.330436, -122.030216, "A-mail@gmail.com", "NickA", "UserA", "refreshTokenA");
+insert into user values(2,"2022-08-02 02:00", "B-Intro", true, true, true, 123456, 37.331184, -122.02311, "B-mail@naver.com", "NickB", "UserB", "refreshTokenB");
+insert into user values(3,"2022-08-03 03:00", "C-Intro", true, true, true, 123456, 37.337542, -122.036574, "C-mail@daum.com", "NickC", "UserC", "refreshTokenC");
 
-insert into user values(4,"2022-08-04 04:00", "D-Intro", true, true, true, 123456, 37.337542, -122.038444, "D-mail@gmail.com", "NickD", "UserD");
-insert into user values(5,"2022-08-05 05:00", "E-Intro", true, true, true, 123456, 37.337542, -122.041062, "E-mail@dnd.com", "NickE", "UserE");
+insert into user values(4,"2022-08-04 04:00", "D-Intro", true, true, true, 123456, 37.337542, -122.038444, "D-mail@gmail.com", "NickD", "UserD", "refreshTokenD");
+insert into user values(5,"2022-08-05 05:00", "E-Intro", true, true, true, 123456, 37.337542, -122.041062, "E-mail@dnd.com", "NickE", "UserE", "refreshTokenE");
 
-insert into user values(6,"2022-08-06 06:00", "F-Intro", true, true, true, 123456, 37.337542, -122.041062, "F-mail@gmail.com", "NickF", "UserF");
-insert into user values(7,"2022-08-07 07:00", "G-Intro", true, true, true, 123456, 37.337542, -122.041062, "G-mail@naver.com", "NickG", "UserG");
+insert into user values(6,"2022-08-06 06:00", "F-Intro", true, true, true, 123456, 37.337542, -122.041062, "F-mail@gmail.com", "NickF", "UserF", "refreshTokenF");
+insert into user values(7,"2022-08-07 07:00", "G-Intro", true, true, true, 123456, 37.337542, -122.041062, "G-mail@naver.com", "NickG", "UserG", "refreshTokenG");
 
-insert into user values(8,"2022-08-08 08:00", "H-Intro", true, true, true, 123456, 37.337542, -122.041062, "H-mail@dnd.com", "NickH", "UserH");
-insert into user values(9,"2022-08-09 09:00", "I-Intro", true, true, true, 123456, 37.337542, -122.041062, "I-mail@daum.com", "NickI", "UserI");
+insert into user values(8,"2022-08-08 08:00", "H-Intro", true, true, true, 123456, 37.337542, -122.041062, "H-mail@dnd.com", "NickH", "UserH", "refreshTokenH");
+insert into user values(9,"2022-08-09 09:00", "I-Intro", true, true, true, 123456, 37.337542, -122.041062, "I-mail@daum.com", "NickI", "UserI", "refreshTokenI");
 
 -- 친구 관계 생성
 -- A-B-C는 서로 친구 관계


### PR DESCRIPTION
1. 회원가입, 재로그인 시 검증 후 토큰 발급
2. 리프레시 토큰은 유저 필드에 저장
3. 매 request마다 토큰 검증

`[비고] 기존에 들어있는 user data의 리프레시 토큰을 어떻게 채울지 논의가 필요(오류)`
resolved #102 