### PR TITLE
[MODIFY] 챌린지 관련 Response 변경

### DIFF
--- a/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeController.java
@@ -1,9 +1,7 @@
 package com.dnd.ground.domain.challenge.controller;
 
-import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeMapResponseDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeResponseDto;
+import com.dnd.ground.domain.challenge.ChallengeStatus;
+import com.dnd.ground.domain.challenge.dto.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -15,13 +13,14 @@ import java.util.List;
  * @author  박찬호
  * @since   2022-08-01
  * @updated 1.챌린지 상세보기(지도) 기능 구현
+ *          2.챌린지 관련 Response에 UUID 추가
  *          - 2022.08.26 박찬호
  */
 
 public interface ChallengeController {
-    ResponseEntity<?> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto);
-    ResponseEntity<?> acceptChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto);
-    ResponseEntity<?> rejectChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto);
+    ResponseEntity<ChallengeCreateResponseDto> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto);
+    ResponseEntity<ChallengeStatus> acceptChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto);
+    ResponseEntity<ChallengeStatus> rejectChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto);
     ResponseEntity<List<ChallengeResponseDto.Wait>> getWaitChallenges(@RequestParam("nickname") String nickname);
     ResponseEntity<List<ChallengeResponseDto.Progress>> getProgressChallenges(@RequestParam("nickname") String nickname);
     ResponseEntity<List<ChallengeResponseDto.Invite>> getInviteChallenge(@RequestParam("nickname") String nickname);

--- a/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
@@ -1,15 +1,13 @@
 package com.dnd.ground.domain.challenge.controller;
 
 import com.dnd.ground.domain.challenge.ChallengeStatus;
-import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeMapResponseDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeResponseDto;
+import com.dnd.ground.domain.challenge.dto.*;
 import com.dnd.ground.domain.challenge.service.ChallengeService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +19,7 @@ import java.util.List;
  * @author  박찬호
  * @since   2022-08-01
  * @updated 1.챌린지 상세보기(지도) 기능 구현
+ *          2.챌린지 관련 Response에 UUID 추가
  *          - 2022.08.26 박찬호
  */
 
@@ -35,20 +34,20 @@ public class ChallengeControllerImpl implements ChallengeController {
 
     @PostMapping("/")
     @Operation(summary = "챌린지 생성", description = "챌린지 생성")
-    public ResponseEntity<?> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto) {
-        return challengeService.createChallenge(challengeCreateRequestDto);
+    public ResponseEntity<ChallengeCreateResponseDto> createChallenge(@RequestBody ChallengeCreateRequestDto challengeCreateRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(challengeService.createChallenge(challengeCreateRequestDto));
     }
 
     @PostMapping("/accept")
     @Operation(summary = "챌린지 수락", description = "유저의 챌린지 수락")
-    public ResponseEntity<?> acceptChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto) {
-        return challengeService.changeUserChallengeStatus(requestDto, ChallengeStatus.Progress);
+    public ResponseEntity<ChallengeStatus> acceptChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto) {
+        return ResponseEntity.ok().body(challengeService.changeUserChallengeStatus(requestDto, ChallengeStatus.Progress));
     }
 
     @PostMapping("/reject")
     @Operation(summary = "챌린지 거절", description = "유저의 챌린지 거절")
-    public ResponseEntity<?> rejectChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto) {
-        return challengeService.changeUserChallengeStatus(requestDto, ChallengeStatus.Reject);
+    public ResponseEntity<ChallengeStatus> rejectChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto) {
+        return ResponseEntity.ok().body(challengeService.changeUserChallengeStatus(requestDto, ChallengeStatus.Reject));
     }
 
     @GetMapping("/invite")

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateResponseDto.java
@@ -1,0 +1,33 @@
+package com.dnd.ground.domain.challenge.dto;
+
+import com.dnd.ground.domain.user.dto.UserResponseDto;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * @description 챌린지 생성과 관련한 Response DTO
+ * @author  박찬호
+ * @since   2022-08-26
+ * @updated 1. ResponseDto 생성
+ *          - 2022.08.26 박찬호
+ */
+
+@Data
+@Builder
+public class ChallengeCreateResponseDto {
+    @ApiModelProperty(value = "회원 목록", example = "\"users\": [{\"nickname\": \"NickB\"}]")
+    private List<UserResponseDto.UInfo> users;
+
+    @ApiModelProperty(value = "챌린지 메시지", example = "너~ 가보자고~")
+    private String message;
+
+    @ApiModelProperty(value = "챌린지 시작 날짜", example = "2022-08-16")
+    private LocalDate started;
+    
+    @ApiModelProperty(value = "챌린지 종료 날짜", example = "2022-08-21")
+    private LocalDate ended;
+}

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeResponseDto.java
@@ -16,8 +16,8 @@ import java.util.List;
  * @description 챌린지와 관련한 Response DTO
  * @author  박찬호
  * @since   2022-08-12
- * @updated 1. API 명세 수정
- *          - 2022.08.18 박찬호
+ * @updated 1. 챌린지 관련 Response에 UUID 추가
+ *          - 2022.08.26 박찬호
  */
 
 
@@ -30,6 +30,9 @@ public class ChallengeResponseDto {
     static public class CInfoRes {
         @ApiModelProperty(value="챌린지 이름", example="챌린지1")
         private String name;
+
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
 
         @ApiModelProperty(value="챌린지 시작 날짜", example="2022-08-18")
         private LocalDate started;
@@ -48,6 +51,9 @@ public class ChallengeResponseDto {
     static public class Wait {
         @ApiModelProperty(value="챌린지 이름", example="챌린지1")
         private String name;
+
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
 
         @ApiModelProperty(value="챌린지 시작 날짜", example="2022-08-12")
         private LocalDate started;
@@ -72,6 +78,9 @@ public class ChallengeResponseDto {
         @ApiModelProperty(value="챌린지 이름", example="챌린지1")
         private String name;
 
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
+
         @ApiModelProperty(value="챌린지 시작 날짜", example="2022-08-15")
         private LocalDate started;
 
@@ -91,6 +100,9 @@ public class ChallengeResponseDto {
     static public class Done {
         @ApiModelProperty(value="챌린지 이름", example="챌린지1")
         private String name;
+
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
 
         @ApiModelProperty(value="챌린지 시작 날짜", example="2022-08-15")
         private LocalDate started;
@@ -112,6 +124,9 @@ public class ChallengeResponseDto {
         @ApiModelProperty(value="챌린지 이름", example="챌린지A")
         private String name;
 
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
+
         @ApiModelProperty(value="주최자 닉네임(초대자)", example="NickA")
         private String InviterNickname;
 
@@ -128,6 +143,9 @@ public class ChallengeResponseDto {
     static public class Detail {
         @ApiModelProperty(value="챌린지 이름", example="챌린지1")
         private String name;
+
+        @ApiModelProperty(value="챌린지 UUID", example="11ed1e26d25aa6b4b02fbb2d0e652b0f")
+        private String uuid;
 
         @ApiModelProperty(value="챌린지 종류(영역:Widen || 칸:Accumulate)", example="Widen")
         private ChallengeType type;

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
@@ -1,13 +1,8 @@
 package com.dnd.ground.domain.challenge.service;
 
 import com.dnd.ground.domain.challenge.ChallengeStatus;
-import com.dnd.ground.domain.challenge.dto.ChallengeCreateRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeMapResponseDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeRequestDto;
-import com.dnd.ground.domain.challenge.dto.ChallengeResponseDto;
+import com.dnd.ground.domain.challenge.dto.*;
 import com.dnd.ground.domain.exerciseRecord.ExerciseRecord;
-import com.dnd.ground.domain.user.User;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
@@ -16,13 +11,14 @@ import java.util.List;
  * @author  박찬호, 박세헌
  * @since   2022-08-03
  * @updated 1.챌린지 상세보기(지도) 기능 구현
+ *          2.챌린지 관련 Response에 UUID 추가
  *          - 2022.08.26 박찬호
  */
 
 public interface ChallengeService {
 
-    ResponseEntity<?> createChallenge(ChallengeCreateRequestDto challengeCreateRequestDto);
-    ResponseEntity<?> changeUserChallengeStatus(ChallengeRequestDto.CInfo requestDto, ChallengeStatus status);
+    ChallengeCreateResponseDto createChallenge(ChallengeCreateRequestDto challengeCreateRequestDto);
+    ChallengeStatus changeUserChallengeStatus(ChallengeRequestDto.CInfo requestDto, ChallengeStatus status);
 
     void startPeriodChallenge();
     void endPeriodChallenge();

--- a/src/main/java/com/dnd/ground/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/UserResponseDto.java
@@ -28,6 +28,7 @@ import java.util.List;
 public class UserResponseDto {
 
     @Data
+    @AllArgsConstructor
     public static class UInfo {
         private String nickname;
         //프로필 사진 관련 필드 추가 예정


### PR DESCRIPTION
1. 챌린지 관련 Response에 UUID 추가
2. 챌린지 생성 시, Response에 챌린지 관련 정보 추가
3. 유저가 챌린지 수락/거부할 때 변경된 상태값 반환