### PR TITLE
[MODIFY] 회원 인증/인가 및 로그인 관련 로직 분리

### DIFF
--- a/src/main/java/com/dnd/ground/GroundApplication.java
+++ b/src/main/java/com/dnd/ground/GroundApplication.java
@@ -1,15 +1,24 @@
 package com.dnd.ground;
 
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @SpringBootApplication
 public class GroundApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(GroundApplication.class, args);
-	}
+	public static final String APPLICATION_LOCATIONS =
+			"spring.config.location="
+					+ "classpath:application.yml,"
+					+ "classpath:application-dev.properties,"
+//               + "classpath:application-production.properties,"
+					+ "classpath:aws.yml";
 
+	public static void main(String[] args) {
+
+		new SpringApplicationBuilder(GroundApplication.class)
+				.properties(APPLICATION_LOCATIONS)
+				.run(args);
+	}
 }

--- a/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.dnd.ground.domain.user.controller;
 
+import com.dnd.ground.domain.user.service.AuthService;
 import com.dnd.ground.domain.user.service.KakaoService;
 import io.swagger.annotations.Api;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @description 회원 정보와 관련한 컨트롤러
  * @author  박찬호
@@ -17,12 +20,23 @@ import org.springframework.web.bind.annotation.RestController;
  *          - 2022.08.23 박찬호
  */
 
-@Api(tags = "회원 인증/인가")
+@Api(tags = "회원 인증/인가 및 로그인")
 @RequiredArgsConstructor
 @RestController
 public class AuthController {
 
     private final KakaoService kakaoService;
+    private final AuthService authService;
+
+    /*
+    * 클라가 앱에 처음 진입했을때 액세스 토큰이 있다면 토큰과 함께 해당 uri로 호출
+    * (JWTCheckFilter를 거친 후 닉네임 반환)
+    * 토큰이 없다면 카카오 로그인 페이지로 가야함
+    */
+    @GetMapping("/main")
+    public ResponseEntity<?> onBoarding(HttpServletRequest request){
+        return authService.getNicknameByToken(request);
+    }
 
     @GetMapping("/auth/kakao/login")
     @Operation(summary = "카카오 토큰 발급", description = "인가코드를 활용한 카카오 토큰 발급(엑세스, 리프레시)")

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserController.java
@@ -38,5 +38,4 @@ public interface UserController {
 
     ResponseEntity<?> editUserProfile(@RequestBody UserRequestDto.Profile requestDto);
     ResponseEntity<?> getDetailMap(@RequestBody RecordRequestDto.Message requestDto);
-    ResponseEntity<?> main(HttpServletRequest request);
 }

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
@@ -7,6 +7,7 @@ import com.dnd.ground.domain.user.dto.ActivityRecordResponseDto;
 import com.dnd.ground.domain.user.dto.HomeResponseDto;
 import com.dnd.ground.domain.user.dto.UserRequestDto;
 import com.dnd.ground.domain.user.dto.UserResponseDto;
+import com.dnd.ground.domain.user.service.AuthService;
 import com.dnd.ground.domain.user.service.UserService;
 import com.dnd.ground.global.util.JwtUtil;
 import com.dnd.ground.global.util.JwtVerifyResult;
@@ -38,6 +39,7 @@ import java.util.Map;
 public class UserControllerImpl implements UserController {
 
     private final UserService userService;
+    private final AuthService authService;
 
     @GetMapping("/home")
     @Operation(summary = "홈 화면 조회",
@@ -114,15 +116,5 @@ public class UserControllerImpl implements UserController {
     @Operation(summary = "운동 기록 메시지 수정", description = "운동 기록 메시지 수정")
     public ResponseEntity<Boolean> getDetailMap(@RequestBody RecordRequestDto.Message requestDto){
         return userService.editRecordMessage(requestDto);
-    }
-
-    /*
-    - 클라가 앱에 처음 진입했을때 액세스 토큰이 있다면 토큰과 함께 해당 uri로 호출
-    - (JWTCheckFilter를 거친 후 닉네임 반환)
-    - 토큰이 없다면 카카오 로그인 페이지로 가야함
-    */
-    @GetMapping("/main")
-    public ResponseEntity<?> main(HttpServletRequest request){
-        return userService.showMain(request);
     }
 }

--- a/src/main/java/com/dnd/ground/domain/user/service/AuthService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/AuthService.java
@@ -1,0 +1,22 @@
+package com.dnd.ground.domain.user.service;
+
+import com.dnd.ground.domain.user.User;
+import com.dnd.ground.domain.user.dto.JwtUserDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+/**
+ * @description 회원의 인증/인가 및 로그인 관련 서비스 인터페이스
+ * @author  박세헌, 박찬호
+ * @since   2022-09-07
+ * @updated 회원 인증/인가 및 로그인 관련 메소드 이동(UserService -> AuthService)
+ *          2022-09-07 박찬호
+ */
+public interface AuthService {
+    User save(JwtUserDto user);
+    ResponseEntity<Map<String, String>> getNicknameByToken(HttpServletRequest request);
+    UserDetails loadUserByUsername(String nickname);
+}

--- a/src/main/java/com/dnd/ground/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/AuthServiceImpl.java
@@ -1,0 +1,83 @@
+package com.dnd.ground.domain.user.service;
+
+import com.dnd.ground.domain.user.User;
+import com.dnd.ground.domain.user.dto.JwtUserDto;
+import com.dnd.ground.domain.user.repository.UserRepository;
+import com.dnd.ground.global.exception.CNotFoundException;
+import com.dnd.ground.global.exception.CommonErrorCode;
+import com.dnd.ground.global.util.JwtUtil;
+import com.dnd.ground.global.util.JwtVerifyResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @description 회원의 인증/인가 및 로그인 관련 서비스 구현체
+ * @author  박세헌, 박찬호
+ * @since   2022-09-07
+ * @updated 회원 인증/인가 및 로그인 관련 메소드 이동(UserService -> AuthService)
+ *          2022-09-07 박찬호
+ */
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthServiceImpl implements AuthService, UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    /*회원 저장*/
+    @Transactional
+    public User save(JwtUserDto user){
+        return userRepository.save(User
+                .builder()
+                .kakaoId(user.getId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .mail(user.getMail())
+                .created(LocalDateTime.now())
+                .intro("")
+                .latitude(null)
+                .longitude(null)
+                .isShowMine(true)
+                .isShowFriend(true)
+                .isPublicRecord(true)
+                .build());
+    }
+
+    /* 토큰으로 닉네임 찾은 후 반환하는 함수 */
+    public ResponseEntity<Map<String, String>> getNicknameByToken(HttpServletRequest request){
+        String accessToken = request.getHeader("Access-Token");
+        JwtVerifyResult result = JwtUtil.verify(accessToken.substring("Bearer ".length()));
+
+        Map<String, String> nick = new HashMap<>();
+        nick.put("nickname", result.getNickname());
+
+        return ResponseEntity.ok(nick);
+    }
+
+    /* AuthenticationManager가 User를 검증하는 함수 */
+    @Override
+    public UserDetails loadUserByUsername(String nickname) {
+        User user = userRepository.findByNickname(nickname).orElseThrow(
+                () -> new CNotFoundException(CommonErrorCode.NOT_FOUND_USER)
+        );
+
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(nickname)
+                .password(passwordEncoder.encode(user.getKakaoId()+user.getNickname()))
+                .authorities("BASIC")
+                .build();
+    }
+}

--- a/src/main/java/com/dnd/ground/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/ground/domain/user/service/UserService.java
@@ -15,11 +15,11 @@ import java.time.LocalDateTime;
  * @description 회원 서비스 인터페이스
  * @author  박세헌, 박찬호
  * @since   2022-08-01
- * @updated 2022-08-26 / 컨트롤러-서비스단 전달 형태 변경 - 박세헌
+ * @updated 회원 인증/인가 및 로그인 관련 메소드 이동(UserService -> AuthService)
+ *          2022-09-07 박찬호
  */
 
 public interface UserService {
-    User save(JwtUserDto user);
     HomeResponseDto showHome(String nickname);
     UserResponseDto.Profile getUserInfo(String nickname);
 
@@ -34,8 +34,4 @@ public interface UserService {
 
     ResponseEntity<Boolean> editRecordMessage(RecordRequestDto.Message requestDto);
     ResponseEntity<Boolean> editUserProfile(UserRequestDto.Profile requestDto);
-
-    ResponseEntity<?> showMain(HttpServletRequest request);
-
-    UserDetails loadUserByUsername(String nickname);
 }

--- a/src/main/java/com/dnd/ground/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/ground/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.dnd.ground.global.config;
 
 import com.dnd.ground.domain.user.repository.UserRepository;
+import com.dnd.ground.domain.user.service.AuthService;
 import com.dnd.ground.domain.user.service.UserService;
 import com.dnd.ground.global.securityFilter.JWTCheckFilter;
 import com.dnd.ground.global.securityFilter.JWTSignFilter;
@@ -33,7 +34,7 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
-    private final UserService userService;
+    private final AuthService authService;
     private final UserRepository userRepository;
 
     @Bean
@@ -51,9 +52,9 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         // 회원가입 or 재로그인 인증 필터
-        JWTSignFilter loginFilter = new JWTSignFilter(authenticationManager(authenticationConfiguration), userService, userRepository);
+        JWTSignFilter loginFilter = new JWTSignFilter(authenticationManager(authenticationConfiguration), authService, userRepository);
         // 매 request마다 토큰을 검사 해주는 필터
-        JWTCheckFilter checkFilter = new JWTCheckFilter(authenticationManager(authenticationConfiguration), userService, userRepository);
+        JWTCheckFilter checkFilter = new JWTCheckFilter(authenticationManager(authenticationConfiguration), authService, userRepository);
 
         http
                 .csrf().disable()  // csrf x

--- a/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
+++ b/src/main/java/com/dnd/ground/global/securityFilter/JWTSignFilter.java
@@ -2,7 +2,7 @@ package com.dnd.ground.global.securityFilter;
 
 import com.dnd.ground.domain.user.dto.JwtUserDto;
 import com.dnd.ground.domain.user.repository.UserRepository;
-import com.dnd.ground.domain.user.service.UserService;
+import com.dnd.ground.domain.user.service.AuthService;
 import com.dnd.ground.global.exception.CNotFoundException;
 import com.dnd.ground.global.exception.CommonErrorCode;
 import com.dnd.ground.global.util.JwtUtil;
@@ -13,9 +13,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -37,15 +35,15 @@ import java.io.IOException;
 public class JWTSignFilter extends UsernamePasswordAuthenticationFilter {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final UserService userService;
+    private final AuthService authService;
     private final UserRepository userRepository;
 
     public JWTSignFilter(AuthenticationManager authenticationManager,
-                         UserService userService,
+                         AuthService authService,
                          UserRepository userRepository)
     {
         super(authenticationManager);
-        this.userService = userService;
+        this.authService = authService;
         this.userRepository = userRepository;
         setFilterProcessesUrl("/sign");
     }
@@ -53,8 +51,7 @@ public class JWTSignFilter extends UsernamePasswordAuthenticationFilter {
     // 회원 가입
     @Override
     public Authentication attemptAuthentication(
-            HttpServletRequest request,
-            HttpServletResponse response) throws AuthenticationException
+            HttpServletRequest request, HttpServletResponse response) throws AuthenticationException
     {
         // 정보를 JwtUSerDto에 저장
         JwtUserDto userDto = null;
@@ -67,7 +64,7 @@ public class JWTSignFilter extends UsernamePasswordAuthenticationFilter {
 
         // 신규 회원이면 저장
         if (!userRepository.existsByKakaoId(userDto.getId())){
-            userService.save(userDto);
+            authService.save(userDto);
         }
 
         // id: 닉네임, password: kakaoId + 닉네임


### PR DESCRIPTION
1. 회원의 인증/인가 및 로그인 로직과 기존 서비스를 분리함.
2. AuthController, AuthService 생성
3. Jwt필터가 UserService가 아닌 AuthService에 의존하도록 수정