### PR TITLE
FEAT|MODIFY: 친구, 챌린지 관련 수정 등

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ logs/
 application-dev.properties
 application-production.properties
 aws.yml
+src/main/java/com/dnd/ground/global/securityFilter/JWTDummySignFilter.java
+src/main/java/com/dnd/ground/global/securityFilter/JWTReissueAccessFilter.java

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation "com.fasterxml.uuid:java-uuid-generator:4.0.1"
 
 	//AWS S3
-	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	//WebClient (HTTP Request)
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/com/dnd/ground/domain/challenge/ChallengeStatus.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/ChallengeStatus.java
@@ -2,18 +2,18 @@ package com.dnd.ground.domain.challenge;
 
 /**
  * @description 챌린지 상태(Challenge, UserChallenge 둘 다 사용)
- *              Wait     - 수락 대기
- *              Progress - 진행
- *              Done     - 종료
- *              Reject   - 거절
- *              Master   - 주최자
+ *              Wait       - 수락 대기
+ *              Progress   - 진행
+ *              Done       - 종료
+ *              MasterDone - 챌린지가 종료 후, 주최자의 상태
+ *              Reject     - 거절
+ *              Master     - 주최자
  * @author  박찬호
  * @since   2022-07-26
- * @updated 1. Master - 주최자 추가
- *          2. Reject - 거절 추가
- *          - 2022-08-08 박찬호
+ * @updated 1. MasterDone 추가
+ *          - 2022-10-26 박찬호
  */
 
 public enum ChallengeStatus {
-    Wait, Progress, Done, Reject, Master
+    Wait, Progress, Done, MasterDone, Reject, Master
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/controller/ChallengeControllerImpl.java
@@ -18,9 +18,8 @@ import java.util.List;
  * @description 챌린지와 관련된 컨트롤러 구현체
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1.챌린지 상세보기(지도) 기능 구현
- *          2.챌린지 관련 Response에 UUID 추가
- *          - 2022.08.26 박찬호
+ * @updated 1. 챌린지 삭제 구현
+ *          2022-10-26 박찬호
  */
 
 @Api(tags = "챌린지")
@@ -76,7 +75,7 @@ public class ChallengeControllerImpl implements ChallengeController {
 
     @GetMapping("/detail")
     @Operation(summary = "챌린지 상세 정보 조회", description = "챌린지와 관련된 정보 + 랭킹 관련 정보 + 개인 기록 정보")
-    public ResponseEntity<ChallengeResponseDto.Detail> getDetailProgressChallenge(@ModelAttribute ChallengeRequestDto.CInfo requestDto) {
+    public ResponseEntity<ChallengeResponseDto.Detail> getDetailProgressChallenge(@RequestBody ChallengeRequestDto.CInfo requestDto) {
         return ResponseEntity.ok().body(challengeService.getDetailProgress(requestDto));
     }
 
@@ -84,5 +83,11 @@ public class ChallengeControllerImpl implements ChallengeController {
     @Operation(summary = "챌린지 상세 정보 조회: 지도", description = "챌린지 상세조회에서 지도를 클릭했을 때 보여지는 정보\n챌린지에 참여한 유저 정보+랭킹")
     public ResponseEntity<ChallengeMapResponseDto.Detail> getChallengeDetailMap(@RequestParam("uuid") String uuid) {
         return ResponseEntity.ok().body(challengeService.getChallengeDetailMap(uuid));
+    }
+    //챌린지삭제
+    @PostMapping("/delete")
+    @Operation(summary = "챌린지 삭제", description = "챌린지 생성자의 닉네임과 챌린지 UUID를 통해 챌린지 삭제")
+    public ResponseEntity<Boolean> deleteChallenge(@RequestBody ChallengeRequestDto.CInfo request) {
+        return ResponseEntity.ok().body(challengeService.deleteChallenge(request));
     }
 }

--- a/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/dto/ChallengeCreateResponseDto.java
@@ -19,7 +19,7 @@ import java.util.List;
 @Data
 @Builder
 public class ChallengeCreateResponseDto {
-    @ApiModelProperty(value = "회원 목록", example = "\"users\": [{\"nickname\": \"NickB\"}]")
+    @ApiModelProperty(value = "회원 목록", example = "\\'users\\': [{\\'nickname\\': \\'NickB\\',\\'picturePath\\': https://dnd-ground-bucket.s3.ap-northeast-2.amazonaws.com/user/profile/default_profile.png}]")
     private List<UserResponseDto.UInfo> users;
 
     @ApiModelProperty(value = "챌린지 메시지", example = "너~ 가보자고~")

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
@@ -63,7 +63,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     List<Challenge> findChallengeInWait(@Param("user") User user);
 
     //챌린지 시작 시간이 start~end 사이인 챌린지 조회
-    @Query("select c from Challenge c inner join UserChallenge uc on uc.challenge = c where (uc.status='Progress' or uc.status='Done') " +
+    @Query("select c from Challenge c inner join UserChallenge uc on uc.challenge = c where (uc.status='Progress' or uc.status='Done' or uc.status='MasterDone') " +
             "and uc.user = :user and c.started between :start and :end")
     List<Challenge> findChallengesBetweenStartAndEnd(@Param("user") User user,
                                                      @Param("start") LocalDate start,

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/ChallengeRepository.java
@@ -15,8 +15,8 @@ import java.util.Optional;
  * @description 챌린지와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-03
- * @updated 챌린지 시작 시간이 start~end 사이인 챌린지 조회
- *          - 2022.08.18 박세헌
+ * @updated 조인 시 일부 조건이 빠져있던 문제 해결
+ *          - 2022.10.29 박찬호
  */
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
@@ -42,12 +42,12 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Integer findCountChallenge(@Param("user") User user);
 
     //친구와 함께 진행 중인 챌린지 개수
-    @Query("select count(c.id) from Challenge c where c IN (select uc.challenge from UserChallenge uc where uc.user=:user) and " +
+    @Query("select count(c.id) from Challenge c where c IN (select uc.challenge from UserChallenge uc where uc.user=:user and uc.challenge=c) and " +
             "c.status='Progress' and c = (select uc.challenge from UserChallenge uc where uc.challenge=c and uc.user =:friend)")
     Integer findCountChallenge(@Param("user")User user, @Param("friend") User friend);
 
     //친구와 함께 진행 중인 챌린지 정보 조회
-    @Query("select c from Challenge c where c IN (select uc.challenge from UserChallenge uc where uc.user=:user) and " +
+    @Query("select c from Challenge c where c IN (select uc.challenge from UserChallenge uc where uc.user=:user and uc.challenge=c) and " +
             "c.status='Progress' and c = (select uc.challenge from UserChallenge uc where uc.challenge=c and uc.user =:friend) order by c.id ASC")
     List<Challenge> findChallengesWithFriend(@Param("user")User user, @Param("friend") User friend);
 
@@ -59,7 +59,7 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     List<Challenge> findChallengesByStatusEquals(ChallengeStatus Progress);
 
     //초대 받은 챌린지 조회(UC가 Wait 상태인 챌린지 조회)
-    @Query("select c from Challenge c inner join UserChallenge uc on uc.user=:user where uc.status='Wait' order by c.created ASC")
+    @Query("select c from Challenge c inner join UserChallenge uc on uc.user=:user and uc.challenge=c where uc.status='Wait' order by c.created ASC")
     List<Challenge> findChallengeInWait(@Param("user") User user);
 
     //챌린지 시작 시간이 start~end 사이인 챌린지 조회

--- a/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/repository/UserChallengeRepository.java
@@ -46,7 +46,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     int findUCCount(@Param("challenge") Challenge challenge);
 
     //Progress 상태의 회원 수 조회
-    @Query("select count(uc) from UserChallenge uc where uc.challenge=:challenge and uc.status='Progress'")
+    @Query("select count(uc) from UserChallenge uc where uc.challenge=:challenge and uc.status='Progress' or uc.status='Master'")
     int findUCWaitCount(Challenge challenge);
 
     //유저와 챌린지를 통해 UserChallenge 조회
@@ -67,7 +67,7 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
 
 
     //회원이 참여하고 있는 챌린지 개수 (챌린지 상태 상관X)
-    @Query("select count(uc) from UserChallenge uc where uc.user=:user and (uc.status<>'Done' or uc.status<>'Reject')")
+    @Query("select count(uc) from UserChallenge uc where uc.user=:user and (uc.status<>'Done' or uc.status<>'Reject' or uc.status<>'MasterDone')")
     int findCountChallenge(@Param("user")User user);
 
     //챌린지 색깔 조회

--- a/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/dnd/ground/domain/challenge/service/ChallengeService.java
@@ -10,9 +10,8 @@ import java.util.List;
  * @description 챌린지와 관련된 서비스의 역할을 분리한 인터페이스
  * @author  박찬호, 박세헌
  * @since   2022-08-03
- * @updated 1.챌린지 상세보기(지도) 기능 구현
- *          2.챌린지 관련 Response에 UUID 추가
- *          - 2022.08.26 박찬호
+ * @updated 1. 챌린지 삭제 구현
+ *          2022-10-26 박찬호
  */
 
 public interface ChallengeService {
@@ -33,4 +32,6 @@ public interface ChallengeService {
     ChallengeMapResponseDto.Detail getChallengeDetailMap(String uuid);
 
     List<ChallengeResponseDto.CInfoRes> findChallengeByRecord(ExerciseRecord exerciseRecord);
+
+    Boolean deleteChallenge(ChallengeRequestDto.CInfo request);
 }

--- a/src/main/java/com/dnd/ground/domain/friend/FriendStatus.java
+++ b/src/main/java/com/dnd/ground/domain/friend/FriendStatus.java
@@ -1,15 +1,26 @@
 package com.dnd.ground.domain.friend;
 
 /**
- * @description 친구 상태
+ * @description A가 B에게 친구 요청을 하면, user에 A가, friend에 B가 저장됨.
+ *              FriendStatus는 해당 친구 관계에 대한 상태만을 나타냄.
+ *
+ *              친구 상태
  *              Wait    - 대기
  *              Accept  - 수락
  *              Reject  - 거절
+ *
+ *              친구 요청중, 수락 대기중과 같이 클라이언트에서 필요한 다양한 상황을 정의해놓고, 클라이언트에게 전달할 때 사용한다.
+ *              RequestWait  - 요청 대기중
+ *              ResponseWait - 수락 대기중
+ *              NoFriend     - 친구 아님
+ *
  * @author  박찬호
  * @since   2022-07-28
  * @updated 2022-07-28 / 생성
  */
 
 public enum FriendStatus {
-    Wait, Accept, Reject
+    Wait, Accept, Reject,
+
+    Requesting, ResponseWait, NoFriend
 }

--- a/src/main/java/com/dnd/ground/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/dnd/ground/domain/friend/controller/FriendController.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface FriendController {
     ResponseEntity<FriendResponseDto> getFriends(@RequestParam("nickname") String nickname,
                                                  @RequestParam("offset") Integer offset);
-    ResponseEntity<List<FriendResponseDto.FInfo>> getReceiveRequest(@RequestParam("nickname") String nickname);
+    ResponseEntity<FriendResponseDto.ReceiveRequest> getReceiveRequest(@RequestParam("nickname") String nickname, @RequestParam("offset") Integer offset);
     ResponseEntity<Boolean> requestFriend(@RequestBody FriendRequestDto.Request request);
     ResponseEntity<FriendResponseDto.ResponseResult> responseFriend(@RequestBody FriendRequestDto.Response request);
     ResponseEntity<Boolean> deleteFriend(@RequestBody FriendRequestDto.Request request);

--- a/src/main/java/com/dnd/ground/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/dnd/ground/domain/friend/controller/FriendController.java
@@ -3,21 +3,24 @@ package com.dnd.ground.domain.friend.controller;
 import com.dnd.ground.domain.friend.dto.FriendRequestDto;
 import com.dnd.ground.domain.friend.dto.FriendResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 /**
  * @description 친구와 관련된 컨트롤러의 역할을 분리한 인터페이스
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1.친구 요청 API 구현
- *          2.요청에 대한 응답 API 구현
- *          3.친구 삭제 API 구현
- *          - 2022.10.10 박찬호
+ * @updated 1.친구 목록 조회 페이징 적용
+ *          2.친구 요청 목록 조회 기능 구현
+ *          - 2022.10.29 박찬호
  */
 
 public interface FriendController {
-    ResponseEntity<FriendResponseDto> getFriends(@PathVariable("nickname") String nickname);
+    ResponseEntity<FriendResponseDto> getFriends(@RequestParam("nickname") String nickname,
+                                                 @RequestParam("offset") Integer offset);
+    ResponseEntity<List<FriendResponseDto.FInfo>> getReceiveRequest(@RequestParam("nickname") String nickname);
     ResponseEntity<Boolean> requestFriend(@RequestBody FriendRequestDto.Request request);
     ResponseEntity<FriendResponseDto.ResponseResult> responseFriend(@RequestBody FriendRequestDto.Response request);
     ResponseEntity<Boolean> deleteFriend(@RequestBody FriendRequestDto.Request request);

--- a/src/main/java/com/dnd/ground/domain/friend/controller/FriendControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/friend/controller/FriendControllerImpl.java
@@ -10,14 +10,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * @description 친구와 관련된 컨트롤러 구현체
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1.친구 요청 API 구현
- *          2.요청에 대한 응답 API 구현
- *          3.친구 삭제 API 구현
- *          - 2022.10.10 박찬호
+ * @updated 1.친구 목록 조회 페이징 적용
+ *          2.친구 요청 목록 조회 기능 구현
+ *          - 2022.10.29 박찬호
  */
 
 @Api(tags = "친구")
@@ -29,10 +30,17 @@ public class FriendControllerImpl implements FriendController {
 
     private final FriendService friendService;
 
-    @GetMapping("/list/{nickname}")
-    @Operation(summary = "친구 목록 조회", description = "닉네임을 통해 수락 상태의 친구 조회")
-    public ResponseEntity<FriendResponseDto> getFriends(@PathVariable("nickname") String nickname) {
-        return ResponseEntity.ok(friendService.getFriends(nickname));
+    @GetMapping("/list")
+    @Operation(summary = "친구 목록 조회", description = "닉네임을 통해 수락 상태의 친구 조회\n서버에서 15명씩 결과를 내려주고, 결과값의 isLast=false이면 경우 뒤에 친구가 더 있다는 뜻이므로, offset+1로 요청하면 됨.")
+    public ResponseEntity<FriendResponseDto> getFriends(@RequestParam("nickname") String nickname,
+                                                        @RequestParam("offset") Integer offset) {
+        return ResponseEntity.ok(friendService.getFriends(nickname, offset));
+    }
+
+    @GetMapping("/receive")
+    @Operation(summary = "친구 요청 목록 조회", description = "요청 대기 상태의 친구 목록 조회")
+    public ResponseEntity<List<FriendResponseDto.FInfo>> getReceiveRequest(@RequestParam("nickname") String nickname) {
+        return ResponseEntity.ok(friendService.getReceiveRequest(nickname));
     }
 
     @PostMapping("/request")
@@ -53,12 +61,4 @@ public class FriendControllerImpl implements FriendController {
         return ResponseEntity.ok(friendService.deleteFriend(request.getUserNickname(), request.getFriendNickname()));
     }
 
-//    @PostMapping("/request")
-//    public ResponseEntity<?> requestFriends(@RequestParam("user") String userNickname, @RequestParam("friend") String friendNickname) {
-//        return ResponseEntity.ok(friendService.requestFriends(
-//                userRepository.findByNickname(userNickname).orElseThrow(),
-//                Arrays.asList(userRepository.findByNickname(friendNickname).orElseThrow())
-//                )
-//        );
-//    }
 }

--- a/src/main/java/com/dnd/ground/domain/friend/controller/FriendControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/friend/controller/FriendControllerImpl.java
@@ -38,9 +38,9 @@ public class FriendControllerImpl implements FriendController {
     }
 
     @GetMapping("/receive")
-    @Operation(summary = "친구 요청 목록 조회", description = "요청 대기 상태의 친구 목록 조회")
-    public ResponseEntity<List<FriendResponseDto.FInfo>> getReceiveRequest(@RequestParam("nickname") String nickname) {
-        return ResponseEntity.ok(friendService.getReceiveRequest(nickname));
+    @Operation(summary = "친구 요청 목록 조회", description = "요청 대기 상태의 친구 목록 조회\n서버에서 3명씩 결과를 내려주고, 결과값의 isLast=false이면 경우 뒤에 친구가 더 있다는 뜻이므로, offset+1로 요청하면 됨.")
+    public ResponseEntity<FriendResponseDto.ReceiveRequest> getReceiveRequest(@RequestParam("nickname") String nickname, @RequestParam("offset") Integer offset) {
+        return ResponseEntity.ok(friendService.getReceiveRequest(nickname, offset));
     }
 
     @PostMapping("/request")

--- a/src/main/java/com/dnd/ground/domain/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/friend/dto/FriendResponseDto.java
@@ -16,8 +16,8 @@ import java.util.List;
  * @description 친구와 관련한 정보 조회용 Response DTO
  * @author  박찬호
  * @since   2022-08-02
- * @updated 1.친구 요청에 대한 응답 처리 결과 반환용 DTO 생성 (ResponseResult)
- *          - 2022.10.10 박찬호
+ * @updated 1.페이징 적용에 따른 isLast 필드 추가
+ *          - 2022.10.29 박찬호
  */
 
 @Data @Builder
@@ -28,6 +28,9 @@ public class FriendResponseDto {
 
     @ApiModelProperty(value="친구 수", example="3")
     private Integer size;
+
+    @ApiModelProperty(value="마지막 페이지 여부", example = "true")
+    private Boolean isLast;
 
     
     //친구와 관련한 정보 모음
@@ -61,8 +64,8 @@ public class FriendResponseDto {
         @ApiModelProperty(value = "친구의 소개 메시지", example = "친구의 소개 메시지 예시입니다.")
         private String intro;
 
-        @ApiModelProperty(value = "회원과 친구 관계인지 나타내는 Boolean", example = "true")
-        private Boolean isFriend;
+        @ApiModelProperty(value = "회원과 친구 관계에 대한 정보\nAccept: 친구\nRequesting: 친구 요청중\nResponseWait: 수락 대기중\nNoFriend: 친구 아님", example = "RequestWait")
+        private FriendStatus isFriend;
 
         @ApiModelProperty(value = "이번 주 영역 개수", example = "9")
         private Long areas;
@@ -84,10 +87,10 @@ public class FriendResponseDto {
     /*친구 요청 수락, 거절 등에 대한 결과*/
     @Data @AllArgsConstructor
     static public class ResponseResult {
-        @ApiModelProperty(value = "회원 닉네임(요청받은 사람)", example = "NickA")
+        @ApiModelProperty(value = "회원 닉네임(요청하는 사람)", example = "NickA")
         private String userNickname;
 
-        @ApiModelProperty(value = "친구 닉네임(요청한 사람)", example = "NickB")
+        @ApiModelProperty(value = "친구 닉네임(요청받는 사람)", example = "NickB")
         private String friendNickname;
 
         @ApiModelProperty(value = "변경된 상태(결과: Accept, Reject)", example = "Accept")

--- a/src/main/java/com/dnd/ground/domain/friend/dto/FriendResponseDto.java
+++ b/src/main/java/com/dnd/ground/domain/friend/dto/FriendResponseDto.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -95,6 +96,19 @@ public class FriendResponseDto {
 
         @ApiModelProperty(value = "변경된 상태(결과: Accept, Reject)", example = "Accept")
         private FriendStatus status;
+    }
+
+    @Data
+    @NoArgsConstructor
+    static public class ReceiveRequest {
+        @ApiModelProperty(value="친구 정보 목록", example="['nickname':'NickA','picturePath':'http:\\/\\/k.kakaocdn.net\\/dn\\/uQVeo\\/btrLgESJyjg\\/Pff3k36lRWkQ98ebAlexv1\\/img_640x640.jpg']")
+        List<FInfo> friendsInfo = new ArrayList<>();
+
+        @ApiModelProperty(value="친구 수", example="3")
+        private Integer size;
+
+        @ApiModelProperty(value="마지막 페이지 여부", example = "true")
+        private Boolean isLast;
     }
 
 }

--- a/src/main/java/com/dnd/ground/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/dnd/ground/domain/friend/repository/FriendRepository.java
@@ -3,6 +3,8 @@ package com.dnd.ground.domain.friend.repository;
 import com.dnd.ground.domain.friend.Friend;
 import com.dnd.ground.domain.friend.FriendStatus;
 import com.dnd.ground.domain.user.User;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,16 +16,21 @@ import java.util.Optional;
  * @description 친구와 관련한 레포지토리
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1.친구 관계 여부 조회 쿼리 수정
- *          2.관계 상태에 따른 쿼리 생성
- *          - 2022.10.10 박찬호
+ * @updated 1.요청받은 친구 목록 조회 쿼리 추가
+ *          - 2022.10.29 박찬호
  */
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     //User를 통해 친구 목록 조회
     @Query("select f from Friend f where (f.friend =:user or f.user = :user) and f.status='Accept'")
-    List<Friend> findFriendsById(@Param("user") User user);
+    List<Friend> findFriendsByUser(@Param("user") User user);
+
+    //친구 요청 리스트 조회
+    @Query("select f.user from User u inner join Friend f on f.friend=:user and f.status='Wait' where f.friend=u")
+    List<User> findReceiveRequest(@Param("user") User user);
+
+    Slice<Friend> findFriendsByUserOrFriendAndStatus(@Param("user") User user, @Param("friend") User friend, @Param("status")FriendStatus status, PageRequest pageRequest);
 
     Optional<Friend> findById(Long id);
 

--- a/src/main/java/com/dnd/ground/domain/friend/repository/FriendRepository.java
+++ b/src/main/java/com/dnd/ground/domain/friend/repository/FriendRepository.java
@@ -28,7 +28,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     //친구 요청 리스트 조회
     @Query("select f.user from User u inner join Friend f on f.friend=:user and f.status='Wait' where f.friend=u")
-    List<User> findReceiveRequest(@Param("user") User user);
+    Slice<User> findReceiveRequest(@Param("user") User user, PageRequest pageRequest);
 
     Slice<Friend> findFriendsByUserOrFriendAndStatus(@Param("user") User user, @Param("friend") User friend, @Param("status")FriendStatus status, PageRequest pageRequest);
 

--- a/src/main/java/com/dnd/ground/domain/friend/service/FriendService.java
+++ b/src/main/java/com/dnd/ground/domain/friend/service/FriendService.java
@@ -25,5 +25,5 @@ public interface FriendService {
     Boolean deleteFriend(String userNickname, String friendNickname);
     FriendStatus getFriendStatus(User user, User friend);
 
-    List<FriendResponseDto.FInfo> getReceiveRequest(String nickname);
+    FriendResponseDto.ReceiveRequest getReceiveRequest(String nickname, Integer offset);
 }

--- a/src/main/java/com/dnd/ground/domain/friend/service/FriendService.java
+++ b/src/main/java/com/dnd/ground/domain/friend/service/FriendService.java
@@ -10,23 +10,20 @@ import java.util.List;
  * @description 친구와 관련된 서비스의 역할을 분리한 인터페이스
  * @author  박찬호
  * @since   2022-08-01
- * @updated 1.친구 요청 API 구현
- *          2.요청에 대한 응답 API 구현
- *          3.친구 삭제 API 구현
- *          - 2022.10.10 박찬호
+ * @updated 1.친구 목록 조회 시, 페이징 적용에 따른 offset 파라미터 추가
+ *          2.친구 요청 목록 조회 기능 구현
+ *          - 2022.10.29 박찬호
  */
 
 public interface FriendService {
-    FriendResponseDto getFriends(String nickname); //친구 목록 조회용 DTO
+    FriendResponseDto getFriends(String nickname, Integer offset); //친구 목록 조회용 DTO
     List<User> getFriends(User user); // 친구 목록 조회
     Boolean requestFriend(String userNickname, String friendNickname);
 
     FriendResponseDto.ResponseResult responseFriend(String userNickname, String friendNickname, FriendStatus status);
 
     Boolean deleteFriend(String userNickname, String friendNickname);
+    FriendStatus getFriendStatus(User user, User friend);
 
-//    Boolean requestFriends(User user, List<User> friends);
-
-//    List<User> getChallenge(User user); // 챌린지 진행중인 친구 목록 조회
-//    List<User> getNotChallenge(User user); //챌린지를 진행중이지 않은 친구 목록 조회
+    List<FriendResponseDto.FInfo> getReceiveRequest(String nickname);
 }

--- a/src/main/java/com/dnd/ground/domain/friend/service/FriendServiceImpl.java
+++ b/src/main/java/com/dnd/ground/domain/friend/service/FriendServiceImpl.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.Optional;
 
 /**
+ * @author 박찬호
  * @description 친구와 관련된 서비스 구현체
- * @author  박찬호
- * @since   2022-08-01
  * @updated 1.친구 목록 조회 페이징 적용
- *          2.친구 요청 목록 조회 기능 구현
- *          - 2022.10.29 박찬호
+ * 2.친구 요청 목록 조회 기능 구현
+ * - 2022.10.29 박찬호
+ * @since 2022-08-01
  */
 
 @Slf4j
@@ -35,7 +35,8 @@ public class FriendServiceImpl implements FriendService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
 
-    private final Integer FRIEND_PAGING_NUMBER = 3;
+    private final Integer FRIEND_LARGE_PAGING_NUMBER = 16; //15개씩 페이징하기 위해 1개 더 가져옴(마지막 여부 판단)
+    private final Integer FRIEND_SMALL_PAGING_NUMBER = 4; //3개씩 페이징 하기 위해 1개 더 가져옴.
 
     //친구 목록과 추가 정보를 함께 반환
     @Transactional
@@ -48,50 +49,69 @@ public class FriendServiceImpl implements FriendService {
         List<FriendResponseDto.FInfo> infos = new ArrayList<>();
         boolean isLast = false;
 
-        PageRequest pageRequest = PageRequest.of(offset, FRIEND_PAGING_NUMBER);
-        List<Friend> findFriends = friendRepository.findFriendsByUserOrFriendAndStatus(user, user, FriendStatus.Accept, pageRequest).getContent();
+        PageRequest pageRequest = PageRequest.of(offset, FRIEND_LARGE_PAGING_NUMBER);
 
-        if (findFriends.size() <= FRIEND_PAGING_NUMBER-1)
-            isLast = true;
+        try {
+            List<Friend> findFriends = friendRepository.findFriendsByUserOrFriendAndStatus(user, user, FriendStatus.Accept, pageRequest).getContent();
 
-        for (Friend findFriend : findFriends) {
-            if (findFriend.getUser() == user) {
-                infos.add(FriendResponseDto.FInfo.of()
-                        .nickname(findFriend.getFriend().getNickname())
-                        .picturePath(findFriend.getFriend().getPicturePath())
-                        .build());
-            } else if (findFriend.getFriend() == user) {
-                infos.add(FriendResponseDto.FInfo.of()
-                        .nickname(findFriend.getUser().getNickname())
-                        .picturePath(findFriend.getFriend().getPicturePath())
-                        .build());
+            if (findFriends.size() <= FRIEND_LARGE_PAGING_NUMBER - 1)
+                isLast = true;
+
+            for (int i = 0; i < findFriends.size() - 1; i++) {
+                Friend findFriend = findFriends.get(i);
+                if (findFriend.getUser() == user) {
+                    infos.add(FriendResponseDto.FInfo.of()
+                            .nickname(findFriend.getFriend().getNickname())
+                            .picturePath(findFriend.getFriend().getPicturePath())
+                            .build());
+                } else if (findFriend.getFriend() == user) {
+                    infos.add(FriendResponseDto.FInfo.of()
+                            .nickname(findFriend.getUser().getNickname())
+                            .picturePath(findFriend.getFriend().getPicturePath())
+                            .build());
+                }
             }
-        }
+            return FriendResponseDto.builder()
+                    .infos(infos)
+                    .size(findFriends.size())
+                    .isLast(isLast)
+                    .build();
 
-        return FriendResponseDto.builder()
-                .infos(infos)
-                .size(findFriends.size())
-                .isLast(isLast)
-                .build();
+        } catch (NullPointerException e) {
+            return FriendResponseDto.builder()
+                    .infos(infos)
+                    .size(0)
+                    .isLast(true)
+                    .build();
+        }
     }
 
     //요청받은 친구 목록 조회
-    public List<FriendResponseDto.FInfo> getReceiveRequest(String nickname) {
+    public FriendResponseDto.ReceiveRequest getReceiveRequest(String nickname, Integer offset) {
         User user = userRepository.findByNickname(nickname).orElseThrow(
                 () -> new CNotFoundException(CommonErrorCode.NOT_FOUND_USER));
 
-        List<FriendResponseDto.FInfo> response = new ArrayList<>();
+        FriendResponseDto.ReceiveRequest response = new FriendResponseDto.ReceiveRequest();
+        boolean isLast = false;
 
-        List<User> receiveRequest = friendRepository.findReceiveRequest(user);
+        PageRequest pageRequest = PageRequest.of(offset, FRIEND_SMALL_PAGING_NUMBER);
+        List<User> receiveRequest = friendRepository.findReceiveRequest(user, pageRequest).getContent();
 
-        for (User friend : receiveRequest) {
-            response.add(
+        if (receiveRequest.size() <= FRIEND_SMALL_PAGING_NUMBER - 1)
+            isLast = true;
+
+        for (int i = 0; i < receiveRequest.size() - 1; i++) {
+            User friend = receiveRequest.get(i);
+            response.getFriendsInfo().add(
                     FriendResponseDto.FInfo.of()
                             .nickname(friend.getNickname())
                             .picturePath(friend.getPicturePath())
                             .build()
             );
         }
+
+        response.setSize(receiveRequest.size());
+        response.setIsLast(isLast);
         return response;
     }
 
@@ -116,6 +136,7 @@ public class FriendServiceImpl implements FriendService {
      * 누가 요청을 보냈는지 알기 위해 다음과 같은 명확한 기준을 세운다.
      * 추후 친구 요청 수락을 위해 요청을 보내는 쪽이 user, 받는 쪽이 friend에 저장한다.
      * 단, 한 친구 관계는 DB에 1번만 저장하도록 한다.
+     *
      * @param userNickname
      * @param friendNickname
      * @return
@@ -132,7 +153,8 @@ public class FriendServiceImpl implements FriendService {
 
         if (friendRepository.findFriendInProgress(user, friend).isPresent() || userNickname.equals(friendNickname)) {
             return false;
-        } {
+        }
+        {
             Friend friendRelation = new Friend(user, friend, FriendStatus.Wait);
             friendRepository.save(friendRelation);
             return true;
@@ -189,8 +211,7 @@ public class FriendServiceImpl implements FriendService {
 
             if (friendRelation.getStatus() == FriendStatus.Accept) {
                 isFriend = FriendStatus.Accept;
-            }
-            else if(friendRelation.getStatus() == FriendStatus.Wait) {
+            } else if (friendRelation.getStatus() == FriendStatus.Wait) {
                 if (friendRelation.getUser() == user)
                     isFriend = FriendStatus.Requesting;
                 else

--- a/src/main/java/com/dnd/ground/domain/user/User.java
+++ b/src/main/java/com/dnd/ground/domain/user/User.java
@@ -112,13 +112,10 @@ public class User {
         return this.isPublicRecord;
     }
 
-    public void updateProfile(String nickname, String intro) {
+    //프로필 수정
+    public void updateProfile(String nickname, String intro, String pictureName, String picturePath) {
         this.nickname = nickname;
         this.intro = intro;
-    }
-
-    //프로필 사진 변경
-    public void updatePicture(String pictureName, String picturePath) {
         this.pictureName = pictureName;
         this.picturePath = picturePath;
     }

--- a/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/AuthController.java
@@ -19,13 +19,11 @@ import java.util.Map;
  * @description 회원의 인증/인가 및 로그인 관련 컨트롤러
  * @author  박찬호
  * @since   2022-08-23
- * @updated 1.온보딩 메소드 URL 변경(/main -> /auth)
- *          2.닉네임 검사 URL 변경(/validate/~ -> /check/~)
- *          3.회원가입 로직 추가
- *          - 2022.09.12 박찬호
+ * @updated 1.카카오 친구 목록 조회 구현
+ *          - 2022.10.29 박찬호
  */
 
-@Api(tags = "회원 인증/인가 및 로그인")
+@Api(tags = "회원 인증/인가, 로그인 및 OAuth(카카오)")
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 @RestController
@@ -80,9 +78,10 @@ public class AuthController {
     }
 
     @GetMapping("/kakao/friend")
-    @Operation(summary = "카카오 엑세스 토큰으로 카카오 친구 불러오기", description = "검수 전이라 팀 멤버들만 친구로 조회할 수 있음.\n현재 페이징 적용X")
+    @Operation(summary = "카카오 엑세스 토큰으로 카카오 친구 불러오기", description = "검수 전이라 팀 멤버들만 친구로 조회할 수 있음.\n15명씩 페이징하도록 했음. 카카오 친구목록 조회의 경우 최초 offset=0, 이후 서버로부터 받은 offset으로 요청해야 함.")
     public ResponseEntity<?> getKakaoFriends(@RequestHeader("Kakao-Access-Token") String token,
+                                 @RequestParam("nickname") String nickname,
                                  @RequestParam("offset") Integer offset) {
-        return ResponseEntity.ok(kakaoService.getKakaoFriends(token, offset));
+        return ResponseEntity.ok(kakaoService.getKakaoFriends(token, nickname, offset));
     }
 }

--- a/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/dnd/ground/domain/user/controller/UserControllerImpl.java
@@ -25,7 +25,7 @@ import org.springframework.web.multipart.MultipartFile;
  *          - 2022-10-22 박찬호
  */
 
-@Api(tags = "유저")
+@Api(tags = "회원")
 @Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/user")
@@ -44,13 +44,13 @@ public class UserControllerImpl implements UserController {
     }
 
     @GetMapping("/info")
-    @Operation(summary = "회원 정보 조회(마이페이지)", description = "회원의 닉네임, 소개 메시지 정보 (추후 프로필 등 추가 예정)")
+    @Operation(summary = "회원 정보 조회(마이페이지)", description = "회원의 닉네임, 소개 메시지 정보")
     public ResponseEntity<UserResponseDto.MyPage> getUserInfo(@RequestParam("nickname") String nickname) {
         return ResponseEntity.ok().body(userService.getUserInfo(nickname));
     }
 
     @GetMapping("/profile")
-    @Operation(summary = "프로필 조회", description = "회원의 닉네임, 소개 메시지 정보 (추후 프로필 등 추가 예정)")
+    @Operation(summary = "프로필 조회", description = "회원의 닉네임, 소개 메시지 정보")
     public ResponseEntity<FriendResponseDto.FriendProfile> getUserProfile(
                             @ApiParam(value = "회원 닉네임", required = true) @RequestParam("user") String userNickname,
                             @ApiParam(value = "대상 닉네임", required = true) @RequestParam("friend") String friendNickname) {

--- a/src/main/java/com/dnd/ground/domain/user/dto/KakaoDto.java
+++ b/src/main/java/com/dnd/ground/domain/user/dto/KakaoDto.java
@@ -1,17 +1,19 @@
 package com.dnd.ground.domain.user.dto;
 
+import com.dnd.ground.domain.friend.FriendStatus;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import java.util.Map;
+import java.util.List;
 
 /**
  * @description 카카오 API를 사용할 때 필요한 DTO
  * @author  박찬호
  * @since   2022-08-23
- * @updated 1. 카카오 회원 정보 조회 API 수정
- *          - 2022.09.09 박찬호
+ * @updated 1.친구 목록 조회 관련 DTO 생성
+ *          - 2022.10.29 박찬호
  */
 
 @Data
@@ -54,5 +56,57 @@ public class KakaoDto {
 
         @ApiModelProperty(value="프로필 사진 URI(카카오 프로필 사용 시 kakao/카카오회원번호)", example="http:\\/\\/k.kakaocdn.net\\/dn\\/uQVeo\\/btrLgESJyjg\\/Pff3k36lRWkQ98ebAlexv1\\/img_640x640.jpg")
         private String picturePath;
+    }
+
+    //카카오 친구 목록 조회 결과
+    @Data
+    public static class FriendsInfoFromKakao {
+        private List<KakaoFriend> elements;
+        private Integer total_count;
+        private String before_url;
+        private String after_url;
+        private Integer favorite_count;
+
+        //각 카카오 친구의 정보
+        @Data
+        public static class KakaoFriend {
+            private Long id;
+            private String uuid;
+            private Boolean favorite;
+            private String profile_nickname;
+            private String profile_thumbnail_image;
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class kakaoFriendResponse {
+        @ApiModelProperty(value="다음 친구 목록 요청시 필요한 offset", example="16")
+        private Integer nextOffset;
+
+        @ApiModelProperty(value="이번 페이지의 친구 개수(몇명인지)", example="16")
+        private Integer size;
+
+        @ApiModelProperty(value="마지막 페이지인지(true이면 다음 offset은 0)", example="true")
+        private Boolean isLast;
+
+        @ApiModelProperty(value="친구 정보 리스트", example="[{'nickname':'NickA', 'kakaoName':'박찬호','status':'accept','picturePath':'http:\\/\\/k.kakaocdn.net\\/dn\\/uQVeo\\/btrLgESJyjg\\/Pff3k36lRWkQ98ebAlexv1\\/img_640x640.jpg'}]")
+        private List<FriendsInfo> friendsInfo;
+
+        @Data
+        @Builder
+        public static class FriendsInfo {
+            @ApiModelProperty(value="네모두에서의 닉네임", example="NickA")
+            private String nickname;
+
+            @ApiModelProperty(value="카카오톡에서의 이름", example="박찬호")
+            private String kakaoName;
+
+            @ApiModelProperty(value="나와 카카오친구와의 관계(Accept:친구, Requesting:요청중, ResponseWait:응답대기중, NoFriend:친구아님)", example="Accept")
+            private FriendStatus status;
+
+            @ApiModelProperty(value="프로필 사진 URI(카카오 프로필 사용 시 kakao/카카오회원번호)", example="http:\\/\\/k.kakaocdn.net\\/dn\\/uQVeo\\/btrLgESJyjg\\/Pff3k36lRWkQ98ebAlexv1\\/img_640x640.jpg")
+            private String picturePath;
+        }
     }
 }

--- a/src/main/java/com/dnd/ground/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/ground/global/config/SecurityConfig.java
@@ -27,9 +27,8 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
  * @description 스프링 시큐리티 config 클래스
  * @author  박세헌
  * @since   2022-08-24
- * @updated 1. 로그인 필터 추가
- *          2. 기존 SignFilter의 지역 변수명 변경 (loginFilter -> signFilter)
- *          - 2022-09-25 박찬호
+ * @updated 1. 토큰 재발급 시 필터 제외하도록 수정
+ *          - 2022-10-29 박찬호
  */
 
 @Configuration
@@ -84,7 +83,7 @@ public class SecurityConfig {
     public WebSecurityCustomizer webSecurityCustomizer() {
         return (web) -> web.ignoring()
                 .antMatchers("/doc", "/swagger*/**", "/favicon*/**", "/v2/api-docs")
-                .antMatchers("/auth/signup", "/auth/check/origin", "/auth/check/nickname", "/auth/kakao/login")
+                .antMatchers("/auth/signup", "/auth/check/origin", "/auth/check/nickname", "/auth/kakao/login", "/auth/refreshToken")
                 .antMatchers("/dummy/**");
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     password: ${db.password}
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: ${db.ddl}
     properties:
       hibernate:
         format_sql: true
@@ -19,7 +19,7 @@ spring:
       matching-strategy: ant_path_matcher
   sql:
     init:
-      mode: always
+      mode: ${db.sql.init}
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
1. 챌린지 삭제 기능 구현
2. 챌린지 생성 시, 개수 제한 임시 해제
3. AWS S3에 대한 의존성 변경
4. DB DDL 옵션 관련 profile 분리
5. 친구 요청받은 목록 조회 기능 구현
6. 프로필 수정 시 기본 프로필 사진은 삭제 안하도록 수정
7. 토큰 재발급시 필터에서 제외되도록 수정